### PR TITLE
Remove dev env

### DIFF
--- a/packages/inquiry/env.js
+++ b/packages/inquiry/env.js
@@ -1,8 +1,9 @@
-const { cleanEnv, validators } = require('@base-cms/env');
+const { cleanEnv, validators, str } = require('@base-cms/env');
 
 const { nonemptystr } = validators;
 
 // @todo This should be removed once inquiry is moved to core and the mailer service is created.
 module.exports = cleanEnv(process.env, {
   SENDGRID_API_KEY: nonemptystr({ desc: 'An API key for sending email via SendGrid.' }),
+  SENDGRID_DEV_TO: str({ desc: 'An email address to send development submissions to.', default: '' }),
 });

--- a/packages/inquiry/env.js
+++ b/packages/inquiry/env.js
@@ -1,9 +1,8 @@
-const { cleanEnv, validators, str } = require('@base-cms/env');
+const { cleanEnv, validators } = require('@base-cms/env');
 
 const { nonemptystr } = validators;
 
 // @todo This should be removed once inquiry is moved to core and the mailer service is created.
 module.exports = cleanEnv(process.env, {
   SENDGRID_API_KEY: nonemptystr({ desc: 'An API key for sending email via SendGrid.' }),
-  SENDGRID_DEV_TO: str({ desc: 'An email address to send development submissions to.' }),
 });


### PR DESCRIPTION
As was done in @endeavorb2b/websites [repo](https://github.com/endeavorb2b/websites/blob/master/packages/common/env.js#L6), remove the dev-only env from the dotenv config to prevent an error in prod when unspecified.