### PR TITLE
Replace incorrect NativeX “card” placement with “default”

### DIFF
--- a/sites/bioopticsworld/server/templates/website-section/index.marko
+++ b/sites/bioopticsworld/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/broadbandtechreport/server/templates/website-section/index.marko
+++ b/sites/broadbandtechreport/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/dentistryiq/server/templates/website-section/index.marko
+++ b/sites/dentistryiq/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/evaluationengineering/server/templates/website-section/index.marko
+++ b/sites/evaluationengineering/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/flowcontrolnetwork/server/templates/website-section/index.marko
+++ b/sites/flowcontrolnetwork/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/offshore-mag/server/templates/website-section/index.marko
+++ b/sites/offshore-mag/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/processingmagazine/server/templates/website-section/index.marko
+++ b/sites/processingmagazine/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/rdhmag/server/templates/website-section/index.marko
+++ b/sites/rdhmag/server/templates/website-section/index.marko
@@ -63,7 +63,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/strategies-u/server/templates/website-section/index.marko
+++ b/sites/strategies-u/server/templates/website-section/index.marko
@@ -70,7 +70,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-list-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"

--- a/sites/watertechonline/server/templates/website-section/index.marko
+++ b/sites/watertechonline/server/templates/website-section/index.marko
@@ -45,7 +45,7 @@ $ const { id, alias, name, pageNode } = data;
         component-name="content-load-more-flow"
         component-input={
           aliases,
-          nativeX: { index: 0, name: 'card', aliases },
+          nativeX: { index: 0, name: "default", aliases },
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"


### PR DESCRIPTION
These sites changed their NativeX config to use `default` named placements. However, the load more call on website section pages were still using the old `card` placement. This corrects that.