### PR TITLE
CS3315-LW: misnomer of home block section

### DIFF
--- a/sites/lightwaveonline/server/templates/index.marko
+++ b/sites/lightwaveonline/server/templates/index.marko
@@ -87,7 +87,7 @@ $ const { id, alias, name, pageNode } = data;
             >
               <website-content-list-flow nodes=nodes>
                 <@header>
-                  <marko-web-link href="/network-automation">Fiber Optics</marko-web-link>
+                  <marko-web-link href="/network-automation">Network Automation</marko-web-link>
                 </@header>
                 <@native-x index=2 name="list1" aliases=["network-automation"] />
               </website-content-list-flow>


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-3315

Alias is network-automation, but the section was titled “Fiber Optics”. Corrected title.