### PR TITLE
CS3327-OS: removed skip setting, no featured/hero

### DIFF
--- a/sites/offshore-mag/server/templates/website-section/resources/maps-posters.marko
+++ b/sites/offshore-mag/server/templates/website-section/resources/maps-posters.marko
@@ -1,4 +1,5 @@
 import { getAsObject } from '@base-cms/object-path';
+import queryFragment from "../../../graphql/fragments/content-list";
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import GAM from "../../../../config/gam";
 
@@ -35,6 +36,16 @@ $ const { id, alias, name, pageNode } = data;
         </@section>
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
+
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-query|{ nodes }|
+        name="website-scheduled-content"
+        params={ sectionId: id, limit: 14, queryFragment }
+      >
+        <website-content-load-more-flow nodes=nodes aliases=aliases />
+      </marko-web-query>
+    </marko-web-resolve-page>
   </@page>
   <@below-page>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
@@ -47,7 +58,7 @@ $ const { id, alias, name, pageNode } = data;
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 14}
+        query-params={ sectionId: id, limit: 14, skip: 14}
         page-input={ for: "website-section", id }
       />
     </marko-web-resolve-page>

--- a/sites/offshore-mag/server/templates/website-section/resources/maps-posters.marko
+++ b/sites/offshore-mag/server/templates/website-section/resources/maps-posters.marko
@@ -47,7 +47,7 @@ $ const { id, alias, name, pageNode } = data;
         }
         fragment-name="content-list"
         query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 14, skip: 12 }
+        query-params={ sectionId: id, limit: 14}
         page-input={ for: "website-section", id }
       />
     </marko-web-resolve-page>


### PR DESCRIPTION
Removed the skip setting, as this custom page doesn’t have any featured, hero, or block-level content to skip over.

https://southcomm.atlassian.net/projects/CS/queues/custom/11/CS-3327