### PR TITLE
CS3332-BTR-Webcasts

### DIFF
--- a/sites/broadbandtechreport/browser/index.js
+++ b/sites/broadbandtechreport/browser/index.js
@@ -5,6 +5,7 @@ import GAM from '@base-cms/marko-web-gam/browser';
 import GCSE from '@base-cms/marko-web-gcse/browser';
 import RevealAd from '@base-cms/marko-web-reveal-ad/browser';
 import Common from '@base-cms-websites/package-common/browser';
+import Inquiry from '@base-cms-websites/package-inquiry/browser';
 
 DefaultTheme(Browser);
 GTM(Browser);
@@ -12,5 +13,6 @@ GAM(Browser);
 GCSE(Browser);
 RevealAd(Browser);
 Common(Browser);
+Inquiry(Browser);
 
 export default Browser;

--- a/sites/broadbandtechreport/server/components/inquiry-form.marko
+++ b/sites/broadbandtechreport/server/components/inquiry-form.marko
@@ -1,0 +1,12 @@
+import { getAsObject } from '@base-cms/object-path';
+
+$ const content = getAsObject(input, 'content');
+
+<div class="inquiry-form">
+  <div class="inquiry-form-header">Request More Information</div>
+  <div class="inquiry-form-body">
+    <p>Fill out the form below to request more information about <marko-web-content-name tag=null obj=content />.</p>
+    <hr>
+    <marko-web-browser-component name="InquiryForm" props={ contentId: content.id, content: content }/>
+  </div>
+</div>

--- a/sites/broadbandtechreport/server/components/marko.json
+++ b/sites/broadbandtechreport/server/components/marko.json
@@ -15,5 +15,8 @@
     },
     "<below-container>": {},
     "<foot>": {}
+  },
+  "<website-inquiry-form>": {
+    "template": "./inquiry-form.marko"
   }
 }

--- a/sites/broadbandtechreport/server/templates/content/index.marko
+++ b/sites/broadbandtechreport/server/templates/content/index.marko
@@ -83,6 +83,16 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                   <@link class="btn btn-lg btn-primary" />
                 </default-theme-content-download>
               </if>
+              <if(type === "webinar")>
+                <default-theme-content-link-url
+                  obj=content
+                  label="Register/View"
+                  target="_blank"
+                />
+              </if>
+              <if(type === "product")>
+                <website-inquiry-form content=content />
+              </if>
             </default-theme-page-contents>
             <aside class="col-lg-4 page-rail">
               <marko-web-gam-display-ad id="gpt-ad-rail1" />


### PR DESCRIPTION
Content template was missing if statements for webinars, which caused the register/view button to not display

https://southcomm.atlassian.net/browse/CS-3332