### PR TITLE
Correct GAM ads basepath for GXC

### DIFF
--- a/sites/gxcontractor/config/gam.js
+++ b/sites/gxcontractor/config/gam.js
@@ -1,6 +1,6 @@
 const GAMConfiguration = require('@base-cms/marko-web-gam/config');
 
-const config = new GAMConfiguration('21687441225', { basePath: 'GSX' });
+const config = new GAMConfiguration('21687441225', { basePath: 'GXC' });
 
 config
   .setTemplate('LB', {


### PR DESCRIPTION
<img width="1207" alt="Screen Shot 2019-11-01 at 10 06 33 AM" src="https://user-images.githubusercontent.com/2855198/68034233-52221900-fc8f-11e9-8ab0-f60a86ebf5e9.png">
