### PR TITLE
Add Free Reports (/white-papers) to menu and secondary nav

### DIFF
--- a/sites/mswmanagement/config/navigation.js
+++ b/sites/mswmanagement/config/navigation.js
@@ -13,6 +13,7 @@ module.exports = {
       { href: '/subscribe', label: 'Subscribe' },
       { href: '/magazine', label: 'Magazine ' },
       { href: '/page/advertise', label: 'Advertise' },
+      { href: '/white-papers', label: 'Free Reports' },
     ],
   },
   tertiary: {
@@ -43,8 +44,8 @@ module.exports = {
     {
       label: 'Resources',
       items: [
-        { href: '/page/advertise', label: 'Advertise' },
         { href: '/magazine', label: 'Magazine' },
+        { href: '/white-papers', label: 'Free Reports' },
       ],
     },
     {


### PR DESCRIPTION
Also removed the extra “Advertise” link from the ham nav. There was one under Resources and another under User Tools