### PR TITLE
DIQ - ad-rail class updated on section pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,16 +24,16 @@ x-env-defaults: &env
   YARN_CACHE_FOLDER: /.yarn-cache
 
 x-env-aerilon: &env-aerilon-staging
-  GRAPHQL_URI: ${GRAPHQL_URI-https://aerilon.graphql-staging.base-cms.io}
-  OEMBED_URI: ${OEMBED_URI-https://aerilon.oembed-staging.base-cms.io}
-  RSS_URI: ${RSS_URI-https://aerilon.rss-staging.base-cms.io}
-  SITEMAPS_URI: ${SITEMAPS_URI-https://aerilon.sitemaps-staging.base-cms.io}
+  GRAPHQL_URI: ${GRAPHQL_URI-https://aerilon.graphql.base-cms-staging.io}
+  OEMBED_URI: ${OEMBED_URI-https://aerilon.oembed.base-cms-staging.io}
+  RSS_URI: ${RSS_URI-https://aerilon.rss.base-cms-staging.io}
+  SITEMAPS_URI: ${SITEMAPS_URI-https://aerilon.sitemaps.base-cms-staging.io}
 
 x-env-picon: &env-picon-staging
-  GRAPHQL_URI: ${GRAPHQL_URI-https://picon.graphql-staging.base-cms.io}
-  OEMBED_URI: ${OEMBED_URI-https://picon.oembed-staging.base-cms.io}
-  RSS_URI: ${RSS_URI-https://picon.rss-staging.base-cms.io}
-  SITEMAPS_URI: ${SITEMAPS_URI-https://picon.sitemaps-staging.base-cms.io}
+  GRAPHQL_URI: ${GRAPHQL_URI-https://picon.graphql.base-cms-staging.io}
+  OEMBED_URI: ${OEMBED_URI-https://picon.oembed.base-cms-staging.io}
+  RSS_URI: ${RSS_URI-https://picon.rss.base-cms-staging.io}
+  SITEMAPS_URI: ${SITEMAPS_URI-https://picon.sitemaps.base-cms-staging.io}
 
 x-env-development: &env-development
   GRAPHQL_URI: ${GRAPHQL_URI-http://host.docker.internal:10002}

--- a/sites/dentistryiq/server/templates/website-section/index.marko
+++ b/sites/dentistryiq/server/templates/website-section/index.marko
@@ -50,7 +50,7 @@ $ const { id, alias, name, pageNode } = data;
           </website-content-list-flow>
         </marko-web-query>
       </div>
-      <div class="col-lg-4 ad-rail">
+      <div class="col-lg-4 mb-block page-rail">
         <marko-web-gam-display-ad id="gpt-ad-rail1" />
         <marko-web-gam-display-ad id="gpt-ad-rail2" />
       </div>


### PR DESCRIPTION
Ads space below the top 300x250 ad:
![Screen Shot 2019-11-20 at 3 56 53 PM](https://user-images.githubusercontent.com/12496550/69281812-975eaa00-0bae-11ea-8617-5dcc8ad4f888.png)

Looks like the home page and content pages already have this change, just the section pages that needed updating