### PR TITLE
Add custom “Summits” block to HCI homepage

### DIFF
--- a/sites/hcinnovationgroup.com/server/graphql/fragments/content-list-body.js
+++ b/sites/hcinnovationgroup.com/server/graphql/fragments/content-list-body.js
@@ -1,0 +1,23 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment WebsiteContentListBodyFragment on Content {
+  id
+  type
+  shortName
+  body
+  published
+  primaryImage {
+    id
+    src
+    alt
+    isLogo
+  }
+  ... on ContentPromotion {
+    linkText
+    linkUrl
+  }
+}
+
+`;

--- a/sites/hcinnovationgroup.com/server/templates/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/index.marko
@@ -1,5 +1,7 @@
+import { getAsObject } from "@base-cms/object-path";
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import queryFragment from "../graphql/fragments/content-list";
+import summitsQueryFragment from "../graphql/fragments/content-list-body";
 import latestIssueFragment from "../graphql/fragments/magazine-latest-issue";
 import GAM from "../../config/gam";
 
@@ -41,14 +43,29 @@ $ const { id, alias, name, pageNode } = data;
 
       <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "summits", limit: 4, queryFragment }
+          name="website-optioned-content"
+          params={ sectionAlias: "summits", optionName: "Pinned", limit: 1, queryFragment: summitsQueryFragment }
         >
-          <website-content-list-flow nodes=nodes display-image=false>
-            <@header>
-              <marko-web-link>Summits</marko-web-link>
-            </@header>
-          </website-content-list-flow>
+          $ const content = nodes[0];
+          $ const primaryImage = getAsObject(content, "primaryImage");
+          $ const siteContext = getAsObject(content, "siteContext");
+
+          <div class="node-list">
+            <marko-web-node-list-header>
+              <marko-web-link href="/summits">Summits</marko-web-link>
+            </marko-web-node-list-header>
+            <marko-web-node
+              type=`${content.type}-content`
+              image-position="top"
+              card=true
+            >
+              <@body>
+                <@text>
+                  <marko-web-content-body tag=null obj=content />
+                </@text>
+              </@body>
+            </marko-web-node>
+          </div>
         </marko-web-query>
       </div>
 

--- a/sites/hcinnovationgroup.com/server/templates/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/index.marko
@@ -47,9 +47,6 @@ $ const { id, alias, name, pageNode } = data;
           params={ sectionAlias: "summits", optionName: "Pinned", limit: 1, queryFragment: summitsQueryFragment }
         >
           $ const content = nodes[0];
-          $ const primaryImage = getAsObject(content, "primaryImage");
-          $ const siteContext = getAsObject(content, "siteContext");
-
           <div class="node-list">
             <marko-web-node-list-header>
               <marko-web-link href="/summits">Summits</marko-web-link>


### PR DESCRIPTION
"Unique" block pulls in a pinned piece of content from the Summits section and displays the body field.

<img width="1326" alt="Screen Shot 2019-12-30 at 3 05 55 PM" src="https://user-images.githubusercontent.com/2855198/71600770-17fdb800-2b16-11ea-8443-be9a802bff76.png">
