### PR TITLE
Change Sponsored option name to Pinned on section pages

### DIFF
--- a/sites/aviationpros.com/server/templates/website-section/index.marko
+++ b/sites/aviationpros.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/cpapracticeadvisor.com/server/templates/website-section/index.marko
+++ b/sites/cpapracticeadvisor.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/firehouse.com/server/templates/website-section/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/hcinnovationgroup.com/server/templates/website-section/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/hpnonline.com/server/templates/website-section/index.marko
+++ b/sites/hpnonline.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/locksmithledger.com/server/templates/website-section/index.marko
+++ b/sites/locksmithledger.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/masstransitmag.com/server/templates/website-section/index.marko
+++ b/sites/masstransitmag.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/mlo-online.com/server/templates/website-section/index.marko
+++ b/sites/mlo-online.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/officer.com/server/templates/website-section/index.marko
+++ b/sites/officer.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/plasticsmachinerymagazine.com/server/templates/website-section/index.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/securityinfowatch.com/server/templates/website-section/index.marko
+++ b/sites/securityinfowatch.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/vehicleservicepros.com/server/templates/website-section/index.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/vendingmarketwatch.com/server/templates/website-section/index.marko
+++ b/sites/vendingmarketwatch.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Sponsored",
+                    optionName: "Pinned",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment


### PR DESCRIPTION
On all section landing pages it is throwing the following error:

`An unexpected error occurred: GraphQL error: No website.Option record found for ID {"status":1,"site.$id":"5c33c23175a254e2210041a7","name":"Sponsored"}`

This fixes that.