### PR TITLE
Fix feature companies

### DIFF
--- a/sites/aviationpros.com/server/templates/index.marko
+++ b/sites/aviationpros.com/server/templates/index.marko
@@ -33,7 +33,7 @@ $ const { id, alias, name, pageNode } = data;
 
     <marko-web-query|{ nodes }|
       name="website-optioned-content"
-      params={ sectionId: id, optionName: "Pinned", limit: 5, queryFragment }
+      params={ sectionId: id, optionName: "Sponsored", limit: 5, queryFragment }
     >
       <website-content-hero-flow nodes=nodes />
     </marko-web-query>

--- a/sites/aviationpros.com/server/templates/index.marko
+++ b/sites/aviationpros.com/server/templates/index.marko
@@ -33,7 +33,7 @@ $ const { id, alias, name, pageNode } = data;
 
     <marko-web-query|{ nodes }|
       name="website-optioned-content"
-      params={ sectionId: id, optionName: "Sponsored", limit: 5, queryFragment }
+      params={ sectionId: id, optionName: "Pinned", limit: 5, queryFragment }
     >
       <website-content-hero-flow nodes=nodes />
     </marko-web-query>

--- a/sites/aviationpros.com/server/templates/website-section/index.marko
+++ b/sites/aviationpros.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/cpapracticeadvisor.com/server/templates/website-section/index.marko
+++ b/sites/cpapracticeadvisor.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/firehouse.com/server/templates/website-section/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/hcinnovationgroup.com/server/templates/website-section/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/website-section/index.marko
@@ -44,26 +44,6 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col-lg-12 mb-block">
-              <div class="node-list node-list--inner-justified sponsored">
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={
-                    sectionId: id,
-                    optionName: "Pinned",
-                    limit: 4,
-                    includeContentTypes: ["Company"],
-                    queryFragment
-                  }
-                >
-                  <div class="node-list__header">Featured Companies</div>
-                  <website-content-card-deck-flow nodes=nodes cols=4 display-ads=false with-teaser=false />
-                </marko-web-query>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-lg-12 mb-block">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 0, queryFragment }

--- a/sites/hpnonline.com/server/templates/website-section/index.marko
+++ b/sites/hpnonline.com/server/templates/website-section/index.marko
@@ -44,26 +44,6 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col-lg-12 mb-block">
-              <div class="node-list node-list--inner-justified sponsored">
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={
-                    sectionId: id,
-                    optionName: "Pinned",
-                    limit: 4,
-                    includeContentTypes: ["Company"],
-                    queryFragment
-                  }
-                >
-                  <div class="node-list__header">Featured Companies</div>
-                  <website-content-card-deck-flow nodes=nodes cols=4 display-ads=false with-teaser=false />
-                </marko-web-query>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-lg-12 mb-block">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 0, queryFragment }

--- a/sites/locksmithledger.com/server/templates/website-section/index.marko
+++ b/sites/locksmithledger.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Featured Company",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/masstransitmag.com/server/templates/website-section/index.marko
+++ b/sites/masstransitmag.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/mlo-online.com/server/templates/website-section/index.marko
+++ b/sites/mlo-online.com/server/templates/website-section/index.marko
@@ -44,26 +44,6 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col-lg-12 mb-block">
-              <div class="node-list node-list--inner-justified sponsored">
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={
-                    sectionId: id,
-                    optionName: "Pinned",
-                    limit: 4,
-                    includeContentTypes: ["Company"],
-                    queryFragment
-                  }
-                >
-                  <div class="node-list__header">Featured Companies</div>
-                  <website-content-card-deck-flow nodes=nodes cols=4 display-ads=false with-teaser=false />
-                </marko-web-query>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-lg-12 mb-block">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 0, queryFragment }

--- a/sites/officer.com/server/templates/website-section/index.marko
+++ b/sites/officer.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/plasticsmachinerymagazine.com/server/templates/website-section/index.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/website-section/index.marko
@@ -44,26 +44,6 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col-lg-12 mb-block">
-              <div class="node-list node-list--inner-justified sponsored">
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={
-                    sectionId: id,
-                    optionName: "Pinned",
-                    limit: 4,
-                    includeContentTypes: ["Company"],
-                    queryFragment
-                  }
-                >
-                  <div class="node-list__header">Featured Companies</div>
-                  <website-content-card-deck-flow nodes=nodes cols=4 display-ads=false with-teaser=false />
-                </marko-web-query>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-lg-12 mb-block">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 0, queryFragment }

--- a/sites/securityinfowatch.com/server/templates/website-section/index.marko
+++ b/sites/securityinfowatch.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/vehicleservicepros.com/server/templates/website-section/index.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/index.marko
@@ -49,7 +49,7 @@ $ const { id, alias, name, pageNode } = data;
                   name="website-scheduled-content"
                   params={
                     sectionId: id,
-                    optionName: "Pinned",
+                    optionName: "Sponsored",
                     limit: 4,
                     includeContentTypes: ["Company"],
                     queryFragment

--- a/sites/vendingmarketwatch.com/server/templates/website-section/index.marko
+++ b/sites/vendingmarketwatch.com/server/templates/website-section/index.marko
@@ -44,26 +44,6 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col-lg-12 mb-block">
-              <div class="node-list node-list--inner-justified sponsored">
-                <marko-web-query|{ nodes }|
-                  name="website-scheduled-content"
-                  params={
-                    sectionId: id,
-                    optionName: "Pinned",
-                    limit: 4,
-                    includeContentTypes: ["Company"],
-                    queryFragment
-                  }
-                >
-                  <div class="node-list__header">Featured Companies</div>
-                  <website-content-card-deck-flow nodes=nodes cols=4 display-ads=false with-teaser=false />
-                </marko-web-query>
-              </div>
-            </div>
-          </div>
-
-          <div class="row">
-            <div class="col-lg-12 mb-block">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 0, queryFragment }


### PR DESCRIPTION
Revert previous conversion from sponsored to pinned to add support for Featured Company block where needed.  EBM sites did not have this support or Sponsored option setup so I update as followed.

Removed from:
 - HCI
 - HPM
 - MLO
 - PMM

Update to **Sponsored**:
 - CAVC
 - CPA
 - FH
 - MASS
 - OFCR
 - SIW
 - VSPC
 - VMW

Update to **Featured Company**: 
 - LL

Only example I could find

![Screen Shot 2020-01-06 at 4 11 06 PM](https://user-images.githubusercontent.com/3845869/71853250-62e07800-30a0-11ea-82b9-9ac2d5e946c1.png)
