### PR TITLE
Add `comp_id` GAM targeting to content pages

### DIFF
--- a/packages/common/gam/content-key-values.js
+++ b/packages/common/gam/content-key-values.js
@@ -1,0 +1,7 @@
+const { get } = require('@base-cms/object-path');
+
+module.exports = content => ({
+  cont_id: get(content, 'id'),
+  cont_type: get(content, 'type'),
+  comp_id: get(content, 'company.id'),
+});

--- a/packages/common/gam/content-key-values.js
+++ b/packages/common/gam/content-key-values.js
@@ -1,7 +1,11 @@
 const { get } = require('@base-cms/object-path');
 
-module.exports = content => ({
-  cont_id: get(content, 'id'),
-  cont_type: get(content, 'type'),
-  comp_id: get(content, 'company.id'),
-});
+module.exports = (content) => {
+  const id = get(content, 'id');
+  const type = get(content, 'type');
+  return {
+    cont_id: id,
+    cont_type: type,
+    comp_id: type === 'company' ? id : get(content, 'company.id'),
+  };
+};

--- a/sites/aviationpros.com/server/templates/content/company.marko
+++ b/sites/aviationpros.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/aviationpros.com/server/templates/content/index.marko
+++ b/sites/aviationpros.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/bioopticsworld.com/server/templates/content/company.marko
+++ b/sites/bioopticsworld.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/bioopticsworld.com/server/templates/content/index.marko
+++ b/sites/bioopticsworld.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/broadbandtechreport.com/server/templates/content/company.marko
+++ b/sites/broadbandtechreport.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/broadbandtechreport.com/server/templates/content/index.marko
+++ b/sites/broadbandtechreport.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/cablinginstall.com/server/templates/content/company.marko
+++ b/sites/cablinginstall.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/cablinginstall.com/server/templates/content/index.marko
+++ b/sites/cablinginstall.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/cpapracticeadvisor.com/server/templates/content/company.marko
+++ b/sites/cpapracticeadvisor.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/cpapracticeadvisor.com/server/templates/content/index.marko
+++ b/sites/cpapracticeadvisor.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/dentaleconomics.com/server/templates/content/company.marko
+++ b/sites/dentaleconomics.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/dentaleconomics.com/server/templates/content/index.marko
+++ b/sites/dentaleconomics.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/dentistryiq.com/server/templates/content/company.marko
+++ b/sites/dentistryiq.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/dentistryiq.com/server/templates/content/index.marko
+++ b/sites/dentistryiq.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/distributedenergy.com/server/templates/content/company.marko
+++ b/sites/distributedenergy.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/distributedenergy.com/server/templates/content/index.marko
+++ b/sites/distributedenergy.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/evaluationengineering.com/server/templates/content/company.marko
+++ b/sites/evaluationengineering.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/evaluationengineering.com/server/templates/content/index.marko
+++ b/sites/evaluationengineering.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/firehouse.com/server/templates/content/company.marko
+++ b/sites/firehouse.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/firehouse.com/server/templates/content/index.marko
+++ b/sites/firehouse.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/flowcontrolnetwork.com/server/templates/content/company.marko
+++ b/sites/flowcontrolnetwork.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/flowcontrolnetwork.com/server/templates/content/index.marko
+++ b/sites/flowcontrolnetwork.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/foresternetwork.com/server/templates/content/company.marko
+++ b/sites/foresternetwork.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/foresternetwork.com/server/templates/content/index.marko
+++ b/sites/foresternetwork.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/gxcontractor.com/server/templates/content/company.marko
+++ b/sites/gxcontractor.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/gxcontractor.com/server/templates/content/index.marko
+++ b/sites/gxcontractor.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/hcinnovationgroup.com/server/templates/content/company.marko
+++ b/sites/hcinnovationgroup.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/hcinnovationgroup.com/server/templates/content/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/hpnonline.com/server/templates/content/company.marko
+++ b/sites/hpnonline.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/hpnonline.com/server/templates/content/index.marko
+++ b/sites/hpnonline.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/industrial-lasers.com/server/templates/content/company.marko
+++ b/sites/industrial-lasers.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/industrial-lasers.com/server/templates/content/index.marko
+++ b/sites/industrial-lasers.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/intelligent-aerospace.com/server/templates/content/company.marko
+++ b/sites/intelligent-aerospace.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/intelligent-aerospace.com/server/templates/content/index.marko
+++ b/sites/intelligent-aerospace.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/laserfocusworld.com/server/templates/content/company.marko
+++ b/sites/laserfocusworld.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/laserfocusworld.com/server/templates/content/index.marko
+++ b/sites/laserfocusworld.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/ledsmagazine.com/server/templates/content/company.marko
+++ b/sites/ledsmagazine.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/ledsmagazine.com/server/templates/content/index.marko
+++ b/sites/ledsmagazine.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/lightwaveonline.com/server/templates/content/company.marko
+++ b/sites/lightwaveonline.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/lightwaveonline.com/server/templates/content/index.marko
+++ b/sites/lightwaveonline.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/locksmithledger.com/server/templates/content/company.marko
+++ b/sites/locksmithledger.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/locksmithledger.com/server/templates/content/index.marko
+++ b/sites/locksmithledger.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/masstransitmag.com/server/templates/content/company.marko
+++ b/sites/masstransitmag.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/masstransitmag.com/server/templates/content/index.marko
+++ b/sites/masstransitmag.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/militaryaerospace.com/server/templates/content/company.marko
+++ b/sites/militaryaerospace.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/militaryaerospace.com/server/templates/content/index.marko
+++ b/sites/militaryaerospace.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/mlo-online.com/server/templates/content/company.marko
+++ b/sites/mlo-online.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/mlo-online.com/server/templates/content/index.marko
+++ b/sites/mlo-online.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/mswmanagement.com/server/templates/content/company.marko
+++ b/sites/mswmanagement.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/mswmanagement.com/server/templates/content/index.marko
+++ b/sites/mswmanagement.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/officer.com/server/templates/content/company.marko
+++ b/sites/officer.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/officer.com/server/templates/content/index.marko
+++ b/sites/officer.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/offshore-mag.com/server/templates/content/company.marko
+++ b/sites/offshore-mag.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/offshore-mag.com/server/templates/content/index.marko
+++ b/sites/offshore-mag.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/perioimplantadvisory.com/server/templates/content/company.marko
+++ b/sites/perioimplantadvisory.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/perioimplantadvisory.com/server/templates/content/index.marko
+++ b/sites/perioimplantadvisory.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/plasticsmachinerymagazine.com/server/templates/content/company.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/plasticsmachinerymagazine.com/server/templates/content/index.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/processingmagazine.com/server/templates/content/company.marko
+++ b/sites/processingmagazine.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/processingmagazine.com/server/templates/content/index.marko
+++ b/sites/processingmagazine.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/rdhmag.com/server/templates/content/company.marko
+++ b/sites/rdhmag.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/rdhmag.com/server/templates/content/index.marko
+++ b/sites/rdhmag.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/securityinfowatch.com/server/templates/content/company.marko
+++ b/sites/securityinfowatch.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/securityinfowatch.com/server/templates/content/index.marko
+++ b/sites/securityinfowatch.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/stormh2o.com/server/templates/content/company.marko
+++ b/sites/stormh2o.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/stormh2o.com/server/templates/content/index.marko
+++ b/sites/stormh2o.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/strategies-u.com/server/templates/content/company.marko
+++ b/sites/strategies-u.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/strategies-u.com/server/templates/content/index.marko
+++ b/sites/strategies-u.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/utilityproducts.com/server/templates/content/company.marko
+++ b/sites/utilityproducts.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/utilityproducts.com/server/templates/content/index.marko
+++ b/sites/utilityproducts.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vehicleservicepros.com/server/templates/content/company.marko
+++ b/sites/vehicleservicepros.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vehicleservicepros.com/server/templates/content/index.marko
+++ b/sites/vehicleservicepros.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vendingmarketwatch.com/server/templates/content/company.marko
+++ b/sites/vendingmarketwatch.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vendingmarketwatch.com/server/templates/content/index.marko
+++ b/sites/vendingmarketwatch.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vision-systems.com/server/templates/content/company.marko
+++ b/sites/vision-systems.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/vision-systems.com/server/templates/content/index.marko
+++ b/sites/vision-systems.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/watertechonline.com/server/templates/content/company.marko
+++ b/sites/watertechonline.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/watertechonline.com/server/templates/content/index.marko
+++ b/sites/watertechonline.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/waterworld.com/server/templates/content/company.marko
+++ b/sites/waterworld.com/server/templates/content/company.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -11,8 +12,8 @@ $ const { id, type, pageNode } = data;
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/sites/waterworld.com/server/templates/content/index.marko
+++ b/sites/waterworld.com/server/templates/content/index.marko
@@ -1,5 +1,6 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
 import { get, getAsObject } from "@base-cms/object-path";
+import contentKeyValues from "@endeavor-business-media/package-common/gam/content-key-values";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -14,8 +15,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gtm-content-context|{ context }| id=id>
       <marko-web-gtm-push data=context />
     </marko-web-gtm-content-context>
-    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
+      <marko-web-gam-targeting key-values=contentKeyValues(content) />
+
       $ const aliases = hierarchyAliases(content.primarySection);
       $ const adSlots = {
         "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,11 +778,6 @@
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web-icons/-/marko-web-icons-1.0.0-beta.15.tgz#3ecfe52f2f763d2a2be5667319c79e1ec1007202"
   integrity sha512-Z1k7KZE4d1Wx6C28GvNeh6lzGXFPqc2yH51Ug10SynMNydI/qPwXFvQavxedGBA967qRekSIaTDx1zbM3n6hLA==
 
-"@base-cms/marko-web-icons@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-icons/-/marko-web-icons-1.0.0-rc.1.tgz#a34db81d7a812d827cede19f02bc9f61122bb77e"
-  integrity sha512-4wGIz7sciS4zuyyUMF2Xxwnr5navd6WDWmvBlIUnQwAL9nwu8fbI0oPopC88wFXexk7GaadhBuDS2hKT5HPukg==
-
 "@base-cms/marko-web-native-x@^1.0.0-beta.7":
   version "1.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web-native-x/-/marko-web-native-x-1.0.0-beta.7.tgz#bf9c725aec1eabd7c0a2037b2c82a138f9364e1c"
@@ -799,18 +794,6 @@
   dependencies:
     "@base-cms/object-path" "^1.0.0-beta.4"
     "@base-cms/utils" "^1.0.0-beta.4"
-
-"@base-cms/marko-web-theme-default@^1.0.0-beta.15":
-  version "1.0.0-rc.9"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-theme-default/-/marko-web-theme-default-1.0.0-rc.9.tgz#7583937004cb970eecdbd31cda04b31b3c57396e"
-  integrity sha512-4gaEx7MlnrewTcBt7UQmit9BpVparVC/G1wK7JWSHdcqjwnsifhMHOrc//Gv1CwvcFF6KF4pQQCC9cHo0yeKnw==
-  dependencies:
-    "@base-cms/marko-web-icons" "^1.0.0-rc.1"
-    "@base-cms/object-path" "^1.0.0-rc.1"
-    "@base-cms/utils" "^1.0.0-rc.1"
-    bootstrap "4.3.1"
-    graphql "^14.5.4"
-    graphql-tag "^2.10.1"
 
 "@base-cms/marko-web-theme-default@^1.0.0-beta.18":
   version "1.0.0-beta.18"
@@ -858,14 +841,6 @@
     "@base-cms/utils" "^1.0.0-beta.4"
     object-path "^0.11.4"
 
-"@base-cms/object-path@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@base-cms/object-path/-/object-path-1.0.0-rc.1.tgz#b176c41ed92225572044f858829c0f99eeb82a1d"
-  integrity sha512-HjuXf54XbItS/wBUx/tAGCG5M0WdCF3kud94dwXfRnigZY0IxIAiCo+1iAhIpECaeMj0oWeGeL5Olr1EfqQZHw==
-  dependencies:
-    "@base-cms/utils" "^1.0.0-rc.1"
-    object-path "^0.11.4"
-
 "@base-cms/tenant-context@^1.0.0-beta.4":
   version "1.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@base-cms/tenant-context/-/tenant-context-1.0.0-beta.4.tgz#501c74a013c6c8791f3d3d0d5a143fb263f19dcf"
@@ -875,11 +850,6 @@
   version "1.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@base-cms/utils/-/utils-1.0.0-beta.4.tgz#d25eec2484b9529a69de2475fa071f277ebc37be"
   integrity sha512-WtvpT02tDLGFl+79p2zUyIiKenuNEpbpPWcqcIoc5mzdGXvRTxkMAcX2uSXn/soJeW5LSTTQi3xOsLRjtg086g==
-
-"@base-cms/utils@^1.0.0-rc.1":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@base-cms/utils/-/utils-1.0.0-rc.1.tgz#dac2402bdc170e3f39d50e88a86fc069027717ea"
-  integrity sha512-aOYgnTfU5ArW8uFnowX1PlF+3mOZ7RUda/GOohf0gkcGRGF8ZmXws/gHfiwmTJEZh9mzsKtJLAG6E2rMTrJyLg==
 
 "@base-cms/web-cli@^1.0.0-beta.15":
   version "1.0.0-beta.15"


### PR DESCRIPTION
By way of the common GAM `content-key-values.js` builder.