### PR TITLE
Homepage block to query summit content contents directly

### DIFF
--- a/sites/hcinnovationgroup.com/server/templates/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/index.marko
@@ -41,23 +41,19 @@ $ const { id, alias, name, pageNode } = data;
     <div class="row">
 
       <div class="col-lg-4 mb-block">
-        <marko-web-query|{ nodes }|
-          name="website-optioned-content"
-          params={ sectionAlias: "summits", optionName: "Pinned", limit: 1, queryFragment: summitsQueryFragment }
-        >
-          $ const content = nodes[0];
+        <marko-web-query|{ node }| name="content" params={ id: 21069218, queryFragment: summitsQueryFragment }>
           <div class="node-list">
             <marko-web-node-list-header>
-              <marko-web-link href="/summits">Summits</marko-web-link>
+              <marko-web-link href="https://endeavor.swoogo.com/summit_series/Locations">Summits</marko-web-link>
             </marko-web-node-list-header>
             <marko-web-node
-              type=`${content.type}-content`
+              type=`${node.type}-content`
               image-position="top"
               card=true
             >
               <@body>
                 <@text>
-                  <marko-web-content-body tag=null obj=content />
+                  <marko-web-content-body tag=null obj=node />
                 </@text>
               </@body>
             </marko-web-node>


### PR DESCRIPTION
It was previously query the summit section and looking at the only piece of content scheduled there(21069218).  The section has been deleted in order to redirect /summit to https://endeavor.swoogo.com/summit_series/Locations.  This is now causing an error on their homepage.  

This changes it to directly query that single piece of content.

<img width="409" alt="Screen Shot 2020-01-23 at 10 37 24 AM" src="https://user-images.githubusercontent.com/3845869/73004337-b6ef9a00-3dcc-11ea-97e7-e7ee97bcea55.png">
