### PR TITLE
Move HPN Source Guide nav position and adjust header breakpoints

### DIFF
--- a/sites/hpnonline.com/config/navigation.js
+++ b/sites/hpnonline.com/config/navigation.js
@@ -9,11 +9,11 @@ module.exports = {
       { href: '/evs-facility-services', label: 'EVS & Facility Services' },
       { href: '/healthcare-it', label: 'Healthcare IT' },
       { href: '/regulatory', label: 'Regulatory' },
-      { href: 'https://sg.hpnonline.com', label: 'HPN Source Guide' },
     ],
   },
   secondary: {
     items: [
+      { href: 'https://sg.hpnonline.com', label: 'HPN Source Guide' },
       { href: '/continuing-education', label: 'Continuing Education' },
       { href: '/webinars', label: 'Webinars' },
       { href: '/whitepapers', label: 'Whitepapers' },

--- a/sites/hpnonline.com/config/navigation.js
+++ b/sites/hpnonline.com/config/navigation.js
@@ -13,7 +13,6 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: 'https://sg.hpnonline.com', label: 'HPN Source Guide' },
       { href: '/continuing-education', label: 'Continuing Education' },
       { href: '/webinars', label: 'Webinars' },
       { href: '/whitepapers', label: 'Whitepapers' },
@@ -22,6 +21,7 @@ module.exports = {
       { href: '/hall-of-fame', label: 'Hall of Fame' },
       { href: '/page/advertise', label: 'Advertise' },
       { href: '/subscribe', label: 'Subscribe' },
+      { href: 'https://sg.hpnonline.com', label: 'HPN Source Guide' },
     ],
   },
   tertiary: {

--- a/sites/hpnonline.com/server/styles/index.scss
+++ b/sites/hpnonline.com/server/styles/index.scss
@@ -10,7 +10,7 @@ $theme-site-navbar-secondary-type: light;
 
 $theme-site-header-breakpoints: (
   hide-primary: 1150px,
-  hide-secondary: 906px,
+  hide-secondary: 1150px,
   small-logo: 1015px,
   small-text-primary: 10000px,
   small-text-secondary: 10000px


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-4141

The "HPN Source Guide" navigation item was overflowing the main navigation. Moved it to the right side of the secondary navigation list with Deb's approval.

![Screen Shot 2020-01-28 at 3 03 51 PM](https://user-images.githubusercontent.com/6343242/73305387-9a45ce80-41df-11ea-912b-d388e5532ba4.png)
