### PR TITLE
Use Continuing Education parent layout on child pages

### DIFF
--- a/sites/hpnonline.com/server/routes/website-section.js
+++ b/sites/hpnonline.com/server/routes/website-section.js
@@ -43,6 +43,10 @@ module.exports = (app) => {
     template: continuingEducation,
     queryFragment,
   }));
+  app.get('/:alias(continuing-education/*)', withWebsiteSection({
+    template: continuingEducation,
+    queryFragment,
+  }));
   app.get('/:alias([a-z0-9-/]+)', withWebsiteSection({
     template: section,
     queryFragment,


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-4226

Layout: card --> list

Pages are currently a card layout format, assigned child pages of "Continuing Education" to the same custom website section page layout as their parent, which displays the content in list format.

