### PR TITLE
Set tertiary nav color (including search icon) to light

### DIFF
--- a/sites/officer.com/server/styles/index.scss
+++ b/sites/officer.com/server/styles/index.scss
@@ -11,9 +11,9 @@ $theme-site-navbar-secondary-link-color: $light;
 $theme-site-navbar-secondary-link-hover-color: $light;
 $theme-site-navbar-secondary-link-active-color: $light;
 
-$theme-site-navbar-tertiary-link-active-color: $primary;
-$theme-site-navbar-tertiary-link-color: $primary;
-$theme-site-navbar-tertiary-link-hover-color: $primary;
+$theme-site-navbar-tertiary-link-active-color: $light;
+$theme-site-navbar-tertiary-link-color: $light;
+$theme-site-navbar-tertiary-link-hover-color: $light;
 
 $theme-site-navbar-logo-height: 45px;
 $theme-site-navbar-logo-height-sm: 25px;


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/CS-4236

From:
![Screen Shot 2020-02-03 at 1 57 16 PM](https://user-images.githubusercontent.com/6343242/73686303-55adad80-468d-11ea-8aa5-303c90cb1adb.png)

To:
![Screen Shot 2020-02-03 at 1 57 11 PM](https://user-images.githubusercontent.com/6343242/73686304-56464400-468d-11ea-9685-62573ef96e10.png)
