### PR TITLE
Update GAM ad unit paths for `operations-training` alias

### DIFF
--- a/sites/firehouse.com/config/gam.js
+++ b/sites/firehouse.com/config/gam.js
@@ -75,7 +75,7 @@ config
     { name: 'load-more', templateName: 'LM', path: 'safety-health/load-more' },
     { name: 'reskin', path: 'safety-health/reskin' },
   ])
-  .setAliasAdUnits('operations-training', [
+  .setAliasAdUnits('ops-training', [
     { name: 'lb1', templateName: 'LB1', path: 'operations-training/lb1' },
     { name: 'lb2', templateName: 'LB2', path: 'operations-training/lb2' },
     { name: 'rail1', templateName: 'RAIL1', path: 'operations-training/rail1' },

--- a/sites/firehouse.com/config/gam.js
+++ b/sites/firehouse.com/config/gam.js
@@ -75,13 +75,13 @@ config
     { name: 'load-more', templateName: 'LM', path: 'safety-health/load-more' },
     { name: 'reskin', path: 'safety-health/reskin' },
   ])
-  .setAliasAdUnits('ops-training', [
-    { name: 'lb1', templateName: 'LB1', path: 'operations-training/lb1' },
-    { name: 'lb2', templateName: 'LB2', path: 'operations-training/lb2' },
-    { name: 'rail1', templateName: 'RAIL1', path: 'operations-training/rail1' },
-    { name: 'rail2', templateName: 'RAIL2', path: 'operations-training/rail2' },
-    { name: 'load-more', templateName: 'LM', path: 'operations-training/load-more' },
-    { name: 'reskin', path: 'operations-training/reskin' },
+  .setAliasAdUnits('operations-training', [
+    { name: 'lb1', templateName: 'LB1', path: 'ops-training/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'ops-training/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'ops-training/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'ops-training/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'ops-training/load-more' },
+    { name: 'reskin', path: 'ops-training/reskin' },
   ])
   .setAliasAdUnits('careers-education', [
     { name: 'lb1', templateName: 'LB1', path: 'careers-education/lb1' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171163009

Ads aren’t showing up on live due to an incorrect alias