### PR TITLE
Update secondary nav path for breakthrough url

### DIFF
--- a/sites/processingmagazine.com/config/navigation.js
+++ b/sites/processingmagazine.com/config/navigation.js
@@ -15,7 +15,7 @@ module.exports = {
       { href: '/magazine', label: 'Magazine' },
       { href: '/webinars', label: 'Webinars' },
       { href: '/events', label: 'Events' },
-      { href: '/breakthrough-products-awards', label: 'Breakthrough Products Awards' },
+      { href: '/breakthrough-products', label: 'Breakthrough Products Awards' },
     ],
   },
   tertiary: {


### PR DESCRIPTION
Updated the url in the hamburger nav with https://github.com/base-cms-websites/endeavor-business-media/pull/283, but forgot the url in the secondary nav.