### PR TITLE
Reorder homepage sections and update navigation

### DIFF
--- a/sites/plasticsmachinerymagazine.com/config/navigation.js
+++ b/sites/plasticsmachinerymagazine.com/config/navigation.js
@@ -9,7 +9,7 @@ module.exports = {
       { href: '/extrusion', label: 'Extrusion' },
       { href: '/recycling', label: 'Recycling' },
       { href: '/molds-tooling', label: 'Molds & Tooling' },
-      { href: '/rotomolding', label: 'Rotomolding' },
+      { href: '/feature', label: 'Features' },
     ],
   },
   secondary: {
@@ -44,7 +44,7 @@ module.exports = {
         { href: '/extrusion', label: 'Extrusion' },
         { href: '/recycling', label: 'Recycling' },
         { href: '/molds-tooling', label: 'Molds & Tooling' },
-        { href: '/rotomolding', label: 'Rotomolding' },
+        { href: '/feature', label: 'Features' },
       ],
     },
     {

--- a/sites/plasticsmachinerymagazine.com/config/navigation.js
+++ b/sites/plasticsmachinerymagazine.com/config/navigation.js
@@ -50,7 +50,7 @@ module.exports = {
     {
       label: 'Resources',
       items: [
-        { href: '/magazine', label: 'In Print' },
+        { href: '/magazine', label: 'Digital Edition' },
         { href: '/page/advertise', label: 'Advertise' },
         { href: '/contact-us', label: 'Contact Us' },
       ],

--- a/sites/plasticsmachinerymagazine.com/config/navigation.js
+++ b/sites/plasticsmachinerymagazine.com/config/navigation.js
@@ -17,6 +17,7 @@ module.exports = {
       { href: '/magazine', label: 'In Print' },
       { href: '/page/advertise', label: 'Advertise' },
       { href: '/contact-us', label: 'Contact Us' },
+      { href: '/product-innovations', label: 'Product Innovations' },
     ],
   },
   tertiary: {
@@ -53,6 +54,7 @@ module.exports = {
         { href: '/magazine', label: 'Digital Edition' },
         { href: '/page/advertise', label: 'Advertise' },
         { href: '/contact-us', label: 'Contact Us' },
+        { href: '/product-innovations', label: 'Product Innovations' },
       ],
     },
     {

--- a/sites/plasticsmachinerymagazine.com/server/routes/website-section.js
+++ b/sites/plasticsmachinerymagazine.com/server/routes/website-section.js
@@ -19,6 +19,7 @@ const channelAliases = [
   'molds-tooling',
   'rotomolding',
   'feature',
+  'product-innovations',
 ];
 
 module.exports = (app) => {

--- a/sites/plasticsmachinerymagazine.com/server/routes/website-section.js
+++ b/sites/plasticsmachinerymagazine.com/server/routes/website-section.js
@@ -18,6 +18,7 @@ const channelAliases = [
   'recycling',
   'molds-tooling',
   'rotomolding',
+  'feature',
 ];
 
 module.exports = (app) => {

--- a/sites/plasticsmachinerymagazine.com/server/templates/index.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/index.marko
@@ -58,49 +58,7 @@ $ const { id, alias, name, pageNode } = data;
       </div>
 
       <div class="col-lg-4 mb-block">
-          <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "blow-molding", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/blow-molding">Blow Molding</marko-web-link>
-            </@header>
-            <@native-x index=3 name="default" aliases=["blow-molding"] />
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "thermoforming", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/thermoforming">Thermoforming</marko-web-link>
-            </@header>
-            <@native-x index=3 name="default" aliases=["thermoforming"] />
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-          <marko-web-query|{ nodes }|
-          name="website-scheduled-content"
-          params={ sectionAlias: "compounding", limit: 4, queryFragment }
-        >
-          <website-content-list-flow nodes=nodes>
-            <@header>
-              <marko-web-link href="/compounding">Compounding</marko-web-link>
-            </@header>
-            <@native-x index=3 name="default" aliases=["compounding"] />
-          </website-content-list-flow>
-        </marko-web-query>
-      </div>
-      <div class="col-lg-4 mb-block">
-          <marko-web-query|{ nodes }|
           name="website-scheduled-content"
           params={ sectionAlias: "injection-molding", limit: 4, queryFragment }
         >
@@ -115,9 +73,8 @@ $ const { id, alias, name, pageNode } = data;
     </div>
 
     <div class="row">
-
       <div class="col-lg-4 mb-block">
-          <marko-web-query|{ nodes }|
+        <marko-web-query|{ nodes }|
           name="website-scheduled-content"
           params={ sectionAlias: "extrusion", limit: 4, queryFragment }
         >
@@ -126,6 +83,49 @@ $ const { id, alias, name, pageNode } = data;
               <marko-web-link href="/extrusion">Extrusion</marko-web-link>
             </@header>
             <@native-x index=3 name="default" aliases=["extrusion"] />
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "molds-tooling", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/molds-tooling">Molds & Tooling</marko-web-link>
+            </@header>
+            <@native-x index=3 name="default" aliases=["molds-tooling"] />
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "blow-molding", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/blow-molding">Blow Molding</marko-web-link>
+            </@header>
+            <@native-x index=3 name="default" aliases=["blow-molding"] />
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <div class="col-lg-4 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionAlias: "thermoforming", limit: 4, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>
+              <marko-web-link href="/thermoforming">Thermoforming</marko-web-link>
+            </@header>
+            <@native-x index=3 name="default" aliases=["thermoforming"] />
           </website-content-list-flow>
         </marko-web-query>
       </div>
@@ -151,15 +151,15 @@ $ const { id, alias, name, pageNode } = data;
 
     <div class="row">
       <div class="col-lg-4 mb-block">
-          <marko-web-query|{ nodes }|
+        <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ sectionAlias: "molds-tooling", limit: 4, queryFragment }
+          params={ sectionAlias: "compounding", limit: 4, queryFragment }
         >
           <website-content-list-flow nodes=nodes>
             <@header>
-              <marko-web-link href="/molds-tooling">Molds & Tooling</marko-web-link>
+              <marko-web-link href="/compounding">Compounding</marko-web-link>
             </@header>
-            <@native-x index=3 name="default" aliases=["molds-tooling"] />
+            <@native-x index=3 name="default" aliases=["compounding"] />
           </website-content-list-flow>
         </marko-web-query>
       </div>
@@ -167,13 +167,13 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-4 mb-block">
           <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ sectionAlias: "rotomolding", limit: 4, queryFragment }
+          params={ sectionAlias: "feature", limit: 4, queryFragment }
         >
           <website-content-list-flow nodes=nodes>
             <@header>
-              <marko-web-link href="/rotomolding">Rotomolding</marko-web-link>
+              <marko-web-link href="/feature">Features</marko-web-link>
             </@header>
-            <@native-x index=3 name="default" aliases=["rotomolding"] />
+            <@native-x index=3 name="default" aliases=["feature"] />
           </website-content-list-flow>
         </marko-web-query>
       </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171260192

Update the Feature page [https://www.plasticsmachinerymagazine.com/feature] layout to look like the other channels. This page should serve home page ads

Main Nav & Hamburger

Remove 'Rotomolding' and replace with 'Features' and link it to https://www.plasticsmachinerymagazine.com/feature
Create "Product Innovations" section; the page layout should look like the channels

Secondary Nav

Change 'In Print' to 'Digital Edition'
Add 'Product Innovations' to the right of 'Contact Us'
Home page - Re-order the content wells

First row - Additive Manufacturing; Injection Molding
Second row - Extrusion; Molds & Tooling; Blow Molding
Third row - Thermoforming; Recycling
Fourth row - Compounding; Features

**Note** -- Featured section is currently showing blank on the homepage because there is no active content scheduled to that section. Debra has been notified. The same can be said for the new Product Innovations page (/product-innovations), as well as the /feature page.

Current:
<img width="276" alt="Screen Shot 2020-02-13 at 1 33 45 PM" src="https://user-images.githubusercontent.com/6343242/74471301-9b286280-4e65-11ea-9e39-2b6bbec752fb.png">
![old-pmm-homepage](https://user-images.githubusercontent.com/6343242/74471315-a2e80700-4e65-11ea-8350-0b9578cb3cc3.png)


New:
<img width="267" alt="Screen Shot 2020-02-13 at 1 18 01 PM" src="https://user-images.githubusercontent.com/6343242/74471334-ab404200-4e65-11ea-803b-4e5ca6482b32.png">
![pmm-new-homepage](https://user-images.githubusercontent.com/6343242/74471342-ae3b3280-4e65-11ea-9f4a-2f9838105b9c.png)

