### PR TITLE
Correct spelling of “Healthy” section on homepage

### DIFF
--- a/sites/vendingmarketwatch.com/server/templates/index.marko
+++ b/sites/vendingmarketwatch.com/server/templates/index.marko
@@ -114,7 +114,7 @@ $ const { id, alias, name, pageNode } = data;
         >
           <website-content-list-flow nodes=nodes>
             <@header>
-              <marko-web-link href="/healthy-convenience">Heathy Convenience</marko-web-link>
+              <marko-web-link href="/healthy-convenience">Healthy Convenience</marko-web-link>
             </@header>
             <@native-x index=2 name="default" aliases=["healthy-convenience"] />
           </website-content-list-flow>


### PR DESCRIPTION
Current:
<img width="400" alt="Screen Shot 2020-02-13 at 2 06 02 PM" src="https://user-images.githubusercontent.com/6343242/74473990-39b6c280-4e6a-11ea-899d-31c0f7e97e98.png">

New:
<img width="395" alt="Screen Shot 2020-02-13 at 2 08 15 PM" src="https://user-images.githubusercontent.com/6343242/74474038-4cc99280-4e6a-11ea-81b6-04564aef1ceb.png">
