### PR TITLE
Update blog and video section titles to be links

### DIFF
--- a/sites/vehicleservicepros.com/server/templates/website-section/blogs.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/blogs.marko
@@ -43,9 +43,6 @@ $ const { id, alias, name, pageNode } = data;
           <@section|{ blockName }|>
             <div class="row mb-block">
               <div class="col">
-                <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Latest Blogs
-                </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="all-published-content"
                   params={ contentTypes: ["Blog"], limit: 5, queryFragment }
@@ -60,7 +57,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  In The Driver's Seat
+                  <marko-web-link href="/blogs/drivers-seat">In The Driver's Seat</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -76,7 +73,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Kolman's Komments
+                  <marko-web-link href="/blogs/kolmans-komments">Kolman's Komments</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -92,7 +89,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Guest Blogs
+                  <marko-web-link href="/blogs/guest-blogs">Guest Blogs</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -108,7 +105,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Industry Insights
+                  <marko-web-link href="/blogs/industry-insights">Industry Insights</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -124,7 +121,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Labor Time
+                  <marko-web-link href="/shop-operations/employees-hiring">Labor Time</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"

--- a/sites/vehicleservicepros.com/server/templates/website-section/videos.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/videos.marko
@@ -57,7 +57,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Uptime Update
+                  <marko-web-link href="/videos/uptime-update">Uptime Update</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -73,7 +73,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Tool Reviews
+                  <marko-web-link href="/videos/tool-reviews">Tool Reviews</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -89,7 +89,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Kolman's Korner
+                  <marko-web-link href="/videos/kolmans-korner">Kolman's Korner</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"
@@ -105,7 +105,7 @@ $ const { id, alias, name, pageNode } = data;
             <div class="row mb-block">
               <div class="col">
                 <marko-web-element tag="h2" block-name=blockName name="section-title">
-                  Toolbox Topics
+                  <marko-web-link href="/videos/toolbox-topics">Toolbox Topics</marko-web-link>
                 </marko-web-element>
                 <marko-web-query|{ nodes }|
                   name="website-scheduled-content"


### PR DESCRIPTION
- Made the section titles on the videos and blogs page links.
- Removed "latest blogs" title