### PR TITLE
Updated class to remove form from ad column

### DIFF
--- a/sites/vehicleservicepros.com/server/templates/website-section/index.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/index.marko
@@ -76,7 +76,7 @@ $ const { id, alias, name, pageNode } = data;
           </div>
 
           <div class="row">
-            <div class="col-lg-4 page-rail">
+            <div class="col-lg-4 mb-block">
               <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "load-more", size: [300, 600], aliases }) modifiers=["in-card"] />
             </div>
             <div class="col-lg-8 mb-block">


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171288178

Product form is appearing on blog pages, instead of just directory and product pages. Removed page-rail reference.

<img width="351" alt="Screen Shot 2020-02-14 at 6 02 52 PM" src="https://user-images.githubusercontent.com/6343242/74757605-d814a080-523b-11ea-821a-b12aba6da468.png">

Current:
<img width="405" alt="Screen Shot 2020-02-18 at 10 47 11 AM" src="https://user-images.githubusercontent.com/6343242/74757764-101be380-523c-11ea-9949-0ecb60f41673.png">
