### PR TITLE
Add sponsor logos to cont edu template on HPN

### DIFF
--- a/sites/hpnonline.com/server/styles/index.scss
+++ b/sites/hpnonline.com/server/styles/index.scss
@@ -54,6 +54,15 @@ $pswp__root-z-index: $theme-site-header-z-index + 1;
   }
 }
 
+.sponsor-logo {
+  max-height: 15px;
+  margin: 10px;
+  @media (min-width: 1024px) {
+    max-height: 20px;
+    margin: 10px 20px;
+  }
+}
+
 // @todo this should be removed once added to the theme
 .page-contents {
   &__content-body a {

--- a/sites/hpnonline.com/server/templates/website-section/continuing-education.marko
+++ b/sites/hpnonline.com/server/templates/website-section/continuing-education.marko
@@ -40,6 +40,24 @@ $ const description = (data.descrtiption) ? data.description : "";
             </default-theme-breadcrumbs-with-home>
             <h1 class="page-wrapper__title">${title}</h1>
             <div class="page-wrapper__deck">${description}</div>
+            <if(alias === "continuing-education")>
+              <div class="row">
+                <a href="/continuing-education/3m-health-care">
+                  <img
+                    src="https://img.hpnonline.com/files/base/ebm/hpn/image/sponsored/3M-Health-Care.jpg?h=20"
+                    alt="3M Health Care"
+                    class="sponsor-logo"
+                  />
+                </a>
+                <a href="/continuing-education/steris">
+                  <img
+                    src="https://img.hpnonline.com/files/base/ebm/hpn/image/sponsored/Steris-Transparent.jpg?h=20"
+                    alt="Steris"
+                    class="sponsor-logo"
+                  />
+                </a>
+              </div>
+            </if>
           </div>
         </div>
       </@section>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171442863

https://www.hpnonline.com/continuing-education

The sponsor logos would link to their continuing ed pages on the site.

3M Healthcare - https://www.hpnonline.com/continuing-education/3m-health-care

STERIS - https://www.hpnonline.com/continuing-education/steris

Acceptance Criteria - This ticket will be accepted when the sponsor logos appear under the "Continuing Education" heading and link to their respective pages on the site.

![Screen Shot 2020-02-24 at 12 49 10 PM](https://user-images.githubusercontent.com/6343242/75182401-ee23d480-5705-11ea-828d-bb24960ad09b.png)
