### PR TITLE
Setup custom website section, Jobs, on FH

### DIFF
--- a/sites/firehouse.com/config/navigation.js
+++ b/sites/firehouse.com/config/navigation.js
@@ -53,6 +53,7 @@ module.exports = {
     {
       label: 'Resources',
       items: [
+        { href: '/careers-education/jobs', label: 'Jobs' },
         { href: 'https://forums.firehouse.com', label: 'Forums', target: '_blank' },
         { href: '/magazine', label: 'In Print' },
         { href: '/shiftcalendar', label: 'Shift Calendar' },

--- a/sites/firehouse.com/server/components/flows/marko.json
+++ b/sites/firehouse.com/server/components/flows/marko.json
@@ -35,6 +35,8 @@
       "type": "boolean",
       "default-value": false
     },
+    "@flush-x": "boolean",
+    "@flush-y": "boolean",
     "@inner-justified": {
       "type": "boolean",
       "default-value": true

--- a/sites/firehouse.com/server/routes/website-section.js
+++ b/sites/firehouse.com/server/routes/website-section.js
@@ -10,6 +10,8 @@ const channel = require('../templates/website-section/channel');
 const runSurveys = require('../templates/website-section/run-surveys');
 const anniversary = require('../templates/website-section/anniversary');
 const valorAwards = require('../templates/website-section/valor-awards');
+const jobs = require('../templates/website-section/jobs/index');
+const jobsSubmit = require('../templates/website-section/jobs/submit');
 
 const channelAliases = [
   'leadership',
@@ -23,6 +25,16 @@ const channelAliases = [
 ];
 
 module.exports = (app) => {
+  app.get('/:alias(careers-education/jobs)', withWebsiteSection({
+    template: jobs,
+    queryFragment,
+  }));
+  app.get('/:alias(careers-education/jobs/submit)', withWebsiteSection({
+    aliasResolver: () => 'jobs',
+    redirectOnPathMismatch: false,
+    template: jobsSubmit,
+    queryFragment,
+  }));
   app.get('/:alias(leaders)', withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,

--- a/sites/firehouse.com/server/styles/index.scss
+++ b/sites/firehouse.com/server/styles/index.scss
@@ -56,6 +56,21 @@ $pswp__root-z-index: $theme-site-header-z-index + 1;
   }
 }
 
+.firehouse-jobs {
+  margin-bottom: map-get($spacers, block);
+  &__button {
+    font-size: 1.75rem;
+    font-weight: 800;
+    color: $primary;
+    text-transform: uppercase;
+  }
+  &__link {
+    font-size: 1.15rem;
+    font-weight: 800;
+    color: $dark;
+  }
+}
+
 // @todo this should be removed once added to the theme
 .page-contents {
   &__content-body a {

--- a/sites/firehouse.com/server/styles/index.scss
+++ b/sites/firehouse.com/server/styles/index.scss
@@ -77,3 +77,11 @@ $pswp__root-z-index: $theme-site-header-z-index + 1;
     text-decoration: underline;
   }
 }
+
+.page-wrapper {
+  &__section {
+    &--bottom-border {
+      @include marko-web-node-list-border(border-bottom, $width: 2px);
+    }
+  }
+}

--- a/sites/firehouse.com/server/styles/index.scss
+++ b/sites/firehouse.com/server/styles/index.scss
@@ -59,9 +59,11 @@ $pswp__root-z-index: $theme-site-header-z-index + 1;
 .firehouse-jobs {
   margin-bottom: map-get($spacers, block);
   &__button {
-    font-size: 1.75rem;
+    @extend .btn;
+    @extend .btn-primary;
+    font-size: 1.25rem;
     font-weight: 800;
-    color: $primary;
+    color: $light;
     text-transform: uppercase;
   }
   &__link {

--- a/sites/firehouse.com/server/templates/website-section/jobs/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/jobs/index.marko
@@ -1,0 +1,87 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import queryFragment from "../../../graphql/fragments/content-list";
+import GAM from "../../../../config/gam";
+
+$ const { id, alias, name, pageNode } = data;
+$ const { site } = out.global;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      $ const adSlots = {
+          "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+        }
+      <marko-web-gam-slots slots=adSlots />
+    </marko-web-resolve-page>
+  </@head>
+  <@above-container>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
+    </marko-web-resolve-page>
+  </@above-container>
+  <@page>
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-page-wrapper class="mb-block">
+        <@section modifiers=["bottom-border"]>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=section display-self=false />
+              <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
+              <if(section.description)>
+                <p class="page-wrapper__deck">${section.description}</p>
+              </if>
+            </div>
+          </div>
+        </@section>
+        <@section modifiers=["bottom-border"]>
+          <div class="row">
+            <div class="col">
+              <div class="firehouse-jobs">
+                <marko-web-link href=`/${alias}/submit` class="firehouse-jobs__button">
+                  Submit A Job
+                </marko-web-link>
+              </div>
+              <p>Job posting packages are available for both standard and featured listings.</p>
+              <div class="firehouse-jobs">
+                <marko-web-link href=`/${alias}/submit`        class="firehouse-jobs__link">
+                  Click Here to Submit a Job
+                </marko-web-link>
+              </div>
+            </div>
+          </div>
+        </@section>
+        <@section class="infinite-scroll-target">
+          <div class="row">
+            <div class="col">
+              <marko-web-query|{ nodes }|
+                name="website-optioned-content"
+                params={ sectionId: id, optionName: "Pinned", limit: 250, queryFragment }
+              >
+                <website-content-list-flow
+                  nodes=nodes
+                  with-teaser=true
+                  image-position="left"
+                  inner-justified=false
+                  flush-x=true
+                />
+              </marko-web-query>
+            </div>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+    </marko-web-resolve-page>
+  </@foot>
+</marko-web-website-section-page-layout>

--- a/sites/firehouse.com/server/templates/website-section/jobs/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/jobs/index.marko
@@ -30,7 +30,7 @@ $ const { site } = out.global;
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-page-wrapper class="mb-block">
         <@section modifiers=["bottom-border"]>
-          <div class="row">
+          <div class="row mb-block">
             <div class="col">
               <default-theme-website-section-breadcrumbs section=section display-self=false />
               <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
@@ -41,7 +41,7 @@ $ const { site } = out.global;
           </div>
         </@section>
         <@section modifiers=["bottom-border"]>
-          <div class="row">
+          <div class="row mb-block">
             <div class="col">
               <div class="firehouse-jobs">
                 <marko-web-link href=`/${alias}/submit` class="firehouse-jobs__button">

--- a/sites/firehouse.com/server/templates/website-section/jobs/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/jobs/index.marko
@@ -49,11 +49,6 @@ $ const { site } = out.global;
                 </marko-web-link>
               </div>
               <p>Job posting packages are available for both standard and featured listings.</p>
-              <div class="firehouse-jobs">
-                <marko-web-link href=`/${alias}/submit`        class="firehouse-jobs__link">
-                  Click Here to Submit a Job
-                </marko-web-link>
-              </div>
             </div>
           </div>
         </@section>

--- a/sites/firehouse.com/server/templates/website-section/jobs/index.marko
+++ b/sites/firehouse.com/server/templates/website-section/jobs/index.marko
@@ -29,7 +29,7 @@ $ const { site } = out.global;
     <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-page-wrapper class="mb-block">
-        <@section modifiers=["bottom-border"]>
+        <@section>
           <div class="row mb-block">
             <div class="col">
               <default-theme-website-section-breadcrumbs section=section display-self=false />

--- a/sites/firehouse.com/server/templates/website-section/jobs/submit.marko
+++ b/sites/firehouse.com/server/templates/website-section/jobs/submit.marko
@@ -1,0 +1,47 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import GAM from "../../../../config/gam";
+
+$ const { id, alias, name, pageNode } = data;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      $ const adSlots = {
+          "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+        }
+      <marko-web-gam-slots slots=adSlots />
+    </marko-web-resolve-page>
+  </@head>
+  <@page>
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=section />
+              <h1 class="page-wrapper__title">
+                Firehouse Submit A Job
+              </h1>
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div
+            id="wufoo-r1t17men1u0aryr">
+            Fill out my <a href="https://cygnuscorporate.wufoo.com/forms/r1t17men1u0aryr">online form</a>.
+          </div>
+          <script type="text/javascript">
+            var r1t17men1u0aryr;
+            (function(d, t) { var s = d.createElement(t), options = { 'userName':'cygnuscorporate', 'formHash':'r1t17men1u0aryr', 'autoResize':true, 'height':'1882', 'async':true, 'host':'wufoo.com', 'header':'show', 'ssl':true }; s.src = ('https:' == d.location.protocol ?'https://':'http://') + 'secure.wufoo.com/scripts/embed/form.js'; s.onload = s.onreadystatechange = function() { var rs = this.readyState; if (rs) if (rs != 'complete') if (rs != 'loaded') return; try { r1t17men1u0aryr = new WufooForm(); r1t17men1u0aryr.initialize(options); r1t17men1u0aryr.display(); } catch (e) { } }; var scr = d.getElementsByTagName(t)[0], par = scr.parentNode; par.insertBefore(s, scr); })(document, 'script');
+          </script>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+</marko-web-website-section-page-layout>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171450125

Firehouse had a Jobs page on the previous framework that listed submitted jobs in a listing format. It also had a link at the top of the page to 'Submit a Job' that linked to this page: https://legacy.firehouse.com/careers-education/jobs/submit

CURRENT: https://www.firehouse.com/careers-education/jobs

PREVIOUS: https://legacy.firehouse.com/careers-education/jobs

The brand has requested that we restore this page as it was a revenue generating page on the site.

There is a Jobs content type.

I'm not sure where this page https://legacy.firehouse.com/careers-education/jobs/submit went in the move, so let me know if I need to recreate the page and embed the form.

Acceptance Criteria: This ticket will be accepted when the Jobs page is restored on Firehouse.com where the Jobs content type displays in a listing format, and includes the link to submit a job at the top of the page.

![Screen Shot 2020-02-26 at 12 08 51 PM](https://user-images.githubusercontent.com/6343242/75373902-d0cf4180-5890-11ea-8f05-27a6e660c5d4.png)
