### PR TITLE
Rename “Clinical” section to “Dentistry” and update navigation

### DIFF
--- a/sites/dentistryiq.com/config/navigation.js
+++ b/sites/dentistryiq.com/config/navigation.js
@@ -2,7 +2,7 @@ module.exports = {
   primary: {
     items: [
       { href: '/dental-hygiene', label: 'Dental Hygiene' },
-      { href: '/clinical', label: 'Clinical' },
+      { href: '/dentistry', label: 'Dentistry' },
       { href: '/products', label: 'Products' },
       { href: '/practice-management', label: 'Practice Management' },
       { href: '/front-office', label: 'Front Office' },
@@ -38,7 +38,7 @@ module.exports = {
       label: 'Topics',
       items: [
         { href: '/dental-hygiene', label: 'Dental Hygiene' },
-        { href: '/clinical', label: 'Clinical' },
+        { href: '/dentistry', label: 'Dentistry' },
         { href: '/products', label: 'Products' },
         { href: '/practice-management', label: 'Practice Management' },
         { href: '/front-office', label: 'Front Office' },

--- a/sites/dentistryiq.com/server/templates/index.marko
+++ b/sites/dentistryiq.com/server/templates/index.marko
@@ -56,13 +56,13 @@ $ const { id, alias, name, pageNode } = data;
           <div class="col-lg-6 mb-block">
             <marko-web-query|{ nodes }|
               name="website-scheduled-content"
-              params={ sectionAlias: "clinical", limit: 4, queryFragment }
+              params={ sectionAlias: "dentistry", limit: 4, queryFragment }
             >
               <website-content-list-flow nodes=nodes>
                 <@header>
-                  <marko-web-link href="/clinical">Clinical</marko-web-link>
+                  <marko-web-link href="/dentistry">Dentistry</marko-web-link>
                 </@header>
-                <@native-x index=2 name="default" aliases=["clinical"] />
+                <@native-x index=2 name="default" aliases=["dentistry"] />
               </website-content-list-flow>
             </marko-web-query>
           </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171605084

ToDo: need to update alias on Base after the change is released. (Temporarily changed it for verification on local)

Current:
![screenshot-www dentistryiq com-2020 03 03-14_47_33](https://user-images.githubusercontent.com/6343242/75818183-0e830d00-5d5e-11ea-884f-bde00c9e6b9b.png)

New:
![screenshot-0 0 0 0_9717-2020 03 03-14_50_13](https://user-images.githubusercontent.com/6343242/75818364-59048980-5d5e-11ea-8c92-58275031969d.png)


