### PR TITLE
Create custom website section page for COVID-19

### DIFF
--- a/sites/rdhmag.com/server/routes/website-section.js
+++ b/sites/rdhmag.com/server/routes/website-section.js
@@ -6,6 +6,7 @@ const contactUs = require('../templates/website-section/contact-us');
 const jobPostings = require('../templates/website-section/job-postings');
 const queryFragment = require('../graphql/fragments/website-section-page');
 const whitePapers = require('../templates/website-section/white-papers');
+const covid19 = require('../templates/website-section/covid-19');
 
 module.exports = (app) => {
   app.get('/:alias(leaders)', withWebsiteSection({
@@ -18,6 +19,10 @@ module.exports = (app) => {
   }));
   app.get('/:alias(job-postings)', withWebsiteSection({
     template: jobPostings,
+    queryFragment,
+  }));
+  app.get('/:alias(pathology/covid-19)', withWebsiteSection({
+    template: covid19,
     queryFragment,
   }));
   app.get('/:alias(white-papers)', withWebsiteSection({

--- a/sites/rdhmag.com/server/templates/website-section/covid-19.marko
+++ b/sites/rdhmag.com/server/templates/website-section/covid-19.marko
@@ -1,0 +1,90 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { id, alias, name, pageNode } = data;
+
+<marko-web-website-section-page-layout id=id alias=alias name=name>
+  <@head>
+    <marko-web-gtm-website-section-context|{ context }| alias=alias>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-website-section-context>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      $ const adSlots = {
+          "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+          "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases }),
+          "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+        }
+       <marko-web-gam-slots slots=adSlots />
+    </marko-web-resolve-page>
+  </@head>
+  <@above-container>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
+      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
+    </marko-web-resolve-page>
+  </@above-container>
+  <@page>
+    <marko-web-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-page-wrapper class="mb-block">
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=section />
+              <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
+            </div>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+    <marko-web-query|{ nodes }|
+      name="website-optioned-content"
+      params={ sectionId: id, optionName: "Pinned", limit: 5, requiresImage: true, queryFragment }
+    >
+      <website-content-hero-flow nodes=nodes />
+    </marko-web-query>
+
+    <div class="row">
+      <div class="col-lg-8 mb-block">
+        <marko-web-query|{ nodes }|
+          name="website-scheduled-content"
+          params={ sectionId: id, limit: 7, skip: 5, queryFragment }
+        >
+          <website-content-list-flow nodes=nodes>
+            <@header>Featured</@header>
+            <@native-x index=6 name="default" aliases=[alias] />
+          </website-content-list-flow>
+        </marko-web-query>
+      </div>
+      <div class="col-lg-4 page-rail">
+        <marko-web-gam-display-ad id="gpt-ad-rail1" />
+        <marko-web-gam-display-ad id="gpt-ad-rail2" />
+      </div>
+    </div>
+  </@page>
+  <@below-page>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-load-more
+        component-name="content-load-more-flow"
+        component-input={
+          aliases,
+          nativeX: { index: 0, name: "default", aliases },
+        }
+        fragment-name="content-list"
+        query-name="website-scheduled-content"
+        query-params={ sectionId: id, limit: 10, skip: 12 }
+        page-input={ for: "website-section", id }
+      />
+    </marko-web-resolve-page>
+  </@below-page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+    </marko-web-resolve-page>
+  </@foot>
+</marko-web-website-section-page-layout>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171848944

Added a title and breadcrumbs to the Covid-19 custom page

![Screen Shot 2020-03-18 at 7 37 57 AM](https://user-images.githubusercontent.com/6343242/76961580-9be06880-68eb-11ea-83db-95638ec1fdfc.png)
