### PR TITLE
COVID-19 channel changes, homepage reordering

### DIFF
--- a/sites/dentistryiq.com/config/gam.js
+++ b/sites/dentistryiq.com/config/gam.js
@@ -17,6 +17,14 @@ config
     { name: 'reskin', path: 'default/reskin' },
     { name: 'wa', path: 'default/wa' },
   ])
+  .setAliasAdUnits('covid-19', [
+    { name: 'lb1', templateName: 'LB1', path: 'covid-19/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'covid-19/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'covid-19/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'covid-19/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'covid-19/load-more' },
+    { name: 'reskin', path: 'covid-19/reskin' },
+  ])
   .setAliasAdUnits('dental-hygiene', [
     { name: 'lb1', templateName: 'LB1', path: 'dental-hygiene/lb1' },
     { name: 'lb2', templateName: 'LB2', path: 'dental-hygiene/lb2' },

--- a/sites/dentistryiq.com/config/navigation.js
+++ b/sites/dentistryiq.com/config/navigation.js
@@ -53,6 +53,7 @@ module.exports = {
         { href: '/front-office/office-forms', label: 'Front Office Forms' },
         { href: '/magazine', label: 'Magazine' },
         { href: '/videos', label: 'Videos' },
+        { href: '/white-papers', label: 'White Papers' },
         { href: '/webcasts', label: 'Webcasts' },
         { href: '/blogs', label: 'Blogs' },
         { href: '/page/submission-guidelines', label: 'Submission Guidelines' },

--- a/sites/dentistryiq.com/config/navigation.js
+++ b/sites/dentistryiq.com/config/navigation.js
@@ -1,12 +1,13 @@
 module.exports = {
   primary: {
     items: [
-      { href: '/dental-hygiene', label: 'Dental Hygiene' },
+      { href: '/covid-19', label: 'COVID-19' },
       { href: '/dentistry', label: 'Dentistry' },
-      { href: '/products', label: 'Products' },
-      { href: '/practice-management', label: 'Practice Management' },
+      { href: '/dental-hygiene', label: 'Dental Hygiene' },
       { href: '/front-office', label: 'Front Office' },
       { href: '/dental-assisting', label: 'Dental Assisting' },
+      { href: '/practice-management', label: 'Practice Management' },
+      { href: '/products', label: 'Products' },
     ],
   },
   secondary: {
@@ -37,12 +38,13 @@ module.exports = {
     {
       label: 'Topics',
       items: [
-        { href: '/dental-hygiene', label: 'Dental Hygiene' },
+        { href: '/covid-19', label: 'COVID-19' },
         { href: '/dentistry', label: 'Dentistry' },
-        { href: '/products', label: 'Products' },
-        { href: '/practice-management', label: 'Practice Management' },
+        { href: '/dental-hygiene', label: 'Dental Hygiene' },
         { href: '/front-office', label: 'Front Office' },
         { href: '/dental-assisting', label: 'Dental Assisting' },
+        { href: '/practice-management', label: 'Practice Management' },
+        { href: '/products', label: 'Products' },
       ],
     },
     {
@@ -51,7 +53,6 @@ module.exports = {
         { href: '/front-office/office-forms', label: 'Front Office Forms' },
         { href: '/magazine', label: 'Magazine' },
         { href: '/videos', label: 'Videos' },
-        { href: '/white-papers', label: 'White Papers' },
         { href: '/webcasts', label: 'Webcasts' },
         { href: '/blogs', label: 'Blogs' },
         { href: '/page/submission-guidelines', label: 'Submission Guidelines' },

--- a/sites/dentistryiq.com/server/styles/index.scss
+++ b/sites/dentistryiq.com/server/styles/index.scss
@@ -13,10 +13,10 @@ $theme-site-navbar-secondary-bg-color: #fff;
 $theme-site-navbar-secondary-type: light;
 
 $theme-site-header-breakpoints: (
-  hide-primary: 706px,
+  hide-primary: 790px,
   hide-secondary: 550px,
   small-logo: 696px,
-  small-text-primary: 810px,
+  small-text-primary: 885px,
   small-text-secondary: 598px
 );
 

--- a/sites/dentistryiq.com/server/templates/index.marko
+++ b/sites/dentistryiq.com/server/templates/index.marko
@@ -16,7 +16,7 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-8">
         <div class="row">
           <div class="col-lg-6 mb-block">
-            <shared-website-section-list-block alias="dental-hygiene">
+            <shared-website-section-list-block alias="covid-19">
               <@native-x index=2 />
             </shared-website-section-list-block>
           </div>
@@ -34,27 +34,11 @@ $ const { id, alias, name, pageNode } = data;
     </div>
     <div class="row">
       <div class="col-lg-4 mb-block">
-        <shared-website-section-list-block alias="products">
+        <shared-website-section-list-block alias="dental-hygiene">
           <@query-params limit=3 />
           <@native-x index=2 />
         </shared-website-section-list-block>
       </div>
-      <div class="col-lg-4 mb-block">
-        <shared-website-section-list-block alias="practice-management">
-          <@query-params limit=3 />
-          <@native-x index=2 />
-        </shared-website-section-list-block>
-      </div>
-      <div class="col-lg-4 mb-block">
-        <shared-published-content-list-block content-types=["Video"]>
-          <@header>
-            <marko-web-link href="/videos">Videos</marko-web-link>
-          </@header>
-          <@query-params limit=3 />
-        </shared-published-content-list-block>
-      </div>
-    </div>
-    <div class="row">
       <div class="col-lg-4 mb-block">
         <shared-website-section-list-block alias="front-office">
           <@query-params limit=3 />
@@ -67,14 +51,27 @@ $ const { id, alias, name, pageNode } = data;
           <@native-x index=2 />
         </shared-website-section-list-block>
       </div>
+    </div>
+    <div class="row">
       <div class="col-lg-4 mb-block">
-        <shared-website-section-list-block alias="white-papers">
+        <shared-website-section-list-block alias="practice-management">
           <@query-params limit=3 />
-          <@native-x enabled=false />
-          <@list>
-            <@node display-image=false />
-          </@list>
+          <@native-x index=2 />
         </shared-website-section-list-block>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <shared-website-section-list-block alias="products">
+          <@query-params limit=3 />
+          <@native-x index=2 />
+        </shared-website-section-list-block>
+      </div>
+      <div class="col-lg-4 mb-block">
+        <shared-published-content-list-block content-types=["Video"]>
+          <@header>
+            <marko-web-link href="/videos">Videos</marko-web-link>
+          </@header>
+          <@query-params limit=3 />
+        </shared-published-content-list-block>
       </div>
     </div>
   </@page>


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2431161/stories/171859400

- Add override ads for alias covid-19
- Add covid-19 to main nav and hamburger nav
- Reorder navigation to match the list below
- Reorder homepage content wells to match the list below
- Remove whitepaper well from homepage

1. COVID-19
2. DENTISTRY
3. DENTAL HYGIENE
4. FRONT OFFICE
5. DENTAL ASSISTING
6. PRACTICE MANAGEMENT
7. PRODUCTS

Current Nav:
![Screen Shot 2020-03-18 at 12 46 54 PM](https://user-images.githubusercontent.com/6343242/76990825-94828480-6916-11ea-949b-73394f4015a0.png)
![Screen Shot 2020-03-18 at 12 46 48 PM](https://user-images.githubusercontent.com/6343242/76990828-95b3b180-6916-11ea-9876-8493d765cc36.png)

New Nav:

![Screen Shot 2020-03-18 at 12 49 06 PM](https://user-images.githubusercontent.com/6343242/76991004-e75c3c00-6916-11ea-90d7-f6a8dc450fd5.png)
<img width="130" alt="Screen Shot 2020-03-18 at 1 00 55 PM" src="https://user-images.githubusercontent.com/6343242/76992043-9baa9200-6918-11ea-8c93-0849a5eeb2f1.png">


Current Homepage:
![screenshot-www dentistryiq com-2020 03 18-12_50_17](https://user-images.githubusercontent.com/6343242/76991112-0eb30900-6917-11ea-902a-5d4eba85bd96.png)

New Homepage:

![screenshot-0 0 0 0_9717-2020 03 18-13_04_37](https://user-images.githubusercontent.com/6343242/76992325-1673ad00-6919-11ea-9718-5273e0c40868.png)

