### PR TITLE
Add COVID-19 sections

### DIFF
--- a/sites/securityinfowatch.com/config/navigation.js
+++ b/sites/securityinfowatch.com/config/navigation.js
@@ -8,7 +8,7 @@ module.exports = {
       { href: '/residential-technologies', label: 'Residential Tech' },
       { href: '/alarms-monitoring', label: 'Alarms & Monitoring' },
       { href: '/cybersecurity', label: 'Cybersecurity' },
-      { href: '/perimeter-security', label: 'Perimeter' },
+      { href: '/covid-19', label: 'COVID-19' },
     ],
   },
   secondary: {
@@ -45,6 +45,7 @@ module.exports = {
         { href: '/residential-technologies', label: 'Residential Technologies' },
         { href: '/alarms-monitoring', label: 'Alarms & Monitoring' },
         { href: '/cybersecurity', label: 'Cybersecurity' },
+        { href: '/covid-19', label: 'COVID-19' },
         { href: '/perimeter-security', label: 'Perimeter Security' },
       ],
     },

--- a/sites/securityinfowatch.com/server/templates/index.marko
+++ b/sites/securityinfowatch.com/server/templates/index.marko
@@ -237,11 +237,11 @@ $ const { id, alias, name, pageNode } = data;
       <div class="col-lg-4 mb-block">
         <marko-web-query|{ nodes }|
           name="website-scheduled-content"
-          params={ sectionId: id, limit: 4, skip: 9, queryFragment }
+          params={ sectionAlias: "covid-19", limit: 4, queryFragment }
         >
           <website-content-list-flow nodes=nodes>
             <@header>
-              <marko-web-link>More from Security Info Watch</marko-web-link>
+              <marko-web-link href="/covid-19">COVID-19</marko-web-link>
             </@header>
           </website-content-list-flow>
         </marko-web-query>

--- a/sites/securityinfowatch.com/server/templates/index.marko
+++ b/sites/securityinfowatch.com/server/templates/index.marko
@@ -256,7 +256,7 @@ $ const { id, alias, name, pageNode } = data;
         component-input={ aliases }
         fragment-name="content-list"
         query-name="website-scheduled-content"
-        query-params={ sectionId: id, limit: 14, skip: 9 }
+        query-params={ sectionId: id, limit: 14, skip: 5 }
         max-pages=0
         page-input={ for: "website-section", id }
       />


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171867777

- Add COVID-19 to hamburger nav, before Perimeter Security
- Replace Perimeter with COVID-19 on main nav
- Replace "More From..." content block with COVID-19 block

Current:
<img width="135" alt="Screen Shot 2020-03-18 at 6 12 49 PM" src="https://user-images.githubusercontent.com/6343242/77015932-484e3900-6944-11ea-9a51-a6b4717f3c36.png">
![Screen Shot 2020-03-18 at 6 12 43 PM](https://user-images.githubusercontent.com/6343242/77015933-48e6cf80-6944-11ea-8f4b-f6425dca7739.png)
![Screen Shot 2020-03-18 at 6 15 00 PM](https://user-images.githubusercontent.com/6343242/77015992-687df800-6944-11ea-93a7-32529736447c.png)


New:
<img width="143" alt="Screen Shot 2020-03-18 at 6 15 49 PM" src="https://user-images.githubusercontent.com/6343242/77016028-85b2c680-6944-11ea-9fea-d97abdc158d8.png">
![Screen Shot 2020-03-18 at 6 15 45 PM](https://user-images.githubusercontent.com/6343242/77016030-864b5d00-6944-11ea-9f8e-e1800f3fee31.png)
![Screen Shot 2020-03-18 at 6 14 46 PM](https://user-images.githubusercontent.com/6343242/77016031-864b5d00-6944-11ea-9f28-74699ee12121.png)
