### PR TITLE
Converted whitepaper to work identical as document

### DIFF
--- a/packages/shared/components/content-page/contents.marko
+++ b/packages/shared/components/content-page/contents.marko
@@ -80,7 +80,7 @@ $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
         <shared-image-list images=images />
       </if>
 
-      <if(type === "document")>
+      <if(type === "document" || type === "whitepaper")>
         <default-theme-content-download obj=content>
           <@wufoo user-name=site.get("wufoo.userName") />
           <@link class="btn btn-lg btn-primary" />

--- a/packages/shared/components/layouts/content/default.marko
+++ b/packages/shared/components/layouts/content/default.marko
@@ -99,20 +99,12 @@ $ const withFooterAd = defaultValue(input.withFooterAd, true);
                     <${input.bodyRail} block-name="page-rail" ...response />
                   </if>
                   <else>
-                    <if(type === "whitepaper")>
-                      <default-theme-content-download obj=content>
-                        <@wufoo user-name=site.get("wufoo.userName") />
-                        <@link class="btn btn-lg btn-primary" />
-                      </default-theme-content-download>
-                    </if>
-                    <else>
-                      <shared-content-page-right-rail
-                        display-ads=displayAds
-                        page-node=pageNode
-                        display-related-content=displayRelatedContent
-                        ...getAsObject(input, "rightRail")
-                      />
-                    </else>
+                    <shared-content-page-right-rail
+                      display-ads=displayAds
+                      page-node=pageNode
+                      display-related-content=displayRelatedContent
+                      ...getAsObject(input, "rightRail")
+                    />
                   </else>
                 </aside>
               </div>


### PR DESCRIPTION
This allows for consistent  gating logic instead of having one with a download button in the right rail and having to port gating logic into two places.

![whitepaper](https://user-images.githubusercontent.com/3845869/78154076-6fefd780-7401-11ea-8495-93ba5ebe0f9f.jpg)
