### PR TITLE
Updates for /webinars on PMM

### DIFF
--- a/packages/shared/templates/published-content/webinars.marko
+++ b/packages/shared/templates/published-content/webinars.marko
@@ -1,3 +1,7 @@
-<shared-published-content-page-list-layout title="Webcasts">
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const title = defaultValue(data.title, "Webcasts");
+
+<shared-published-content-page-list-layout title=title>
   <@query-params content-types=["Webinar"] sort-field="startDate" sort-order="desc" />
 </shared-published-content-page-list-layout>

--- a/sites/plasticsmachinerymagazine.com/config/navigation.js
+++ b/sites/plasticsmachinerymagazine.com/config/navigation.js
@@ -56,7 +56,6 @@ module.exports = {
         { href: '/page/advertise', label: 'Advertise' },
         { href: '/contact-us', label: 'Contact Us' },
         { href: '/product-innovations', label: 'Product Innovations' },
-        { href: '/webinars', label: 'Webinars' },
       ],
     },
     {

--- a/sites/plasticsmachinerymagazine.com/config/navigation.js
+++ b/sites/plasticsmachinerymagazine.com/config/navigation.js
@@ -56,6 +56,7 @@ module.exports = {
         { href: '/page/advertise', label: 'Advertise' },
         { href: '/contact-us', label: 'Contact Us' },
         { href: '/product-innovations', label: 'Product Innovations' },
+        { href: '/webinars', label: 'Webinars' },
       ],
     },
     {

--- a/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
+++ b/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
@@ -1,6 +1,6 @@
+const webinars = require('@endeavor-business-media/package-shared/templates/published-content/webinars');
 const events = require('@endeavor-business-media/package-shared/templates/published-content/events');
 const videos = require('@endeavor-business-media/package-shared/templates/published-content/videos');
-const webinars = require('../templates/published-content/webinars');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });

--- a/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
+++ b/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
@@ -4,6 +4,6 @@ const videos = require('@endeavor-business-media/package-shared/templates/publis
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webinars', (_, res) => { res.marko(webinars, { title: 'Webinars' }); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
+++ b/sites/plasticsmachinerymagazine.com/server/routes/published-content.js
@@ -1,6 +1,6 @@
-const webinars = require('@endeavor-business-media/package-shared/templates/published-content/webinars');
 const events = require('@endeavor-business-media/package-shared/templates/published-content/events');
 const videos = require('@endeavor-business-media/package-shared/templates/published-content/videos');
+const webinars = require('../templates/published-content/webinars');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });

--- a/sites/plasticsmachinerymagazine.com/server/templates/published-content/webinars.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/published-content/webinars.marko
@@ -1,3 +1,0 @@
-<shared-published-content-page-list-layout title="Webinars">
-  <@query-params content-types=["Webinar"] sort-field="startDate" sort-order="desc" />
-</shared-published-content-page-list-layout>

--- a/sites/plasticsmachinerymagazine.com/server/templates/published-content/webinars.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/published-content/webinars.marko
@@ -1,0 +1,3 @@
+<shared-published-content-page-list-layout title="Webinars">
+  <@query-params content-types=["Webinar"] sort-field="startDate" sort-order="desc" />
+</shared-published-content-page-list-layout>


### PR DESCRIPTION
- Added /webinars to the hamburger resources menu
- Updated page title and description to say “Webinars” instead of “Webcasts” on /webinars

<img width="268" alt="Screen Shot 2020-04-05 at 10 52 45 PM" src="https://user-images.githubusercontent.com/6343242/78519128-58617780-7790-11ea-8027-113fa63e9df9.png">
<img width="646" alt="Screen Shot 2020-04-05 at 10 50 15 PM" src="https://user-images.githubusercontent.com/6343242/78519130-58617780-7790-11ea-8112-9828b57718ed.png">
