### PR TITLE
Updated webcasts block to include whitepapers

### DIFF
--- a/sites/ledsmagazine.com/server/templates/index.marko
+++ b/sites/ledsmagazine.com/server/templates/index.marko
@@ -71,9 +71,9 @@ $ const adSlots = ({ aliases }) => ({
       </div>
 
       <div class="col-lg-4 mb-block">
-        <shared-published-content-list-block content-types=["Webinar"]>
+        <shared-published-content-list-block content-types=["Webinar", "Whitepaper"]>
           <@header>
-            <marko-web-link href="/webcasts">Webcasts</marko-web-link>
+            <marko-web-link href="/webcasts">Webcasts & Whitepapers</marko-web-link>
           </@header>
           <@list>
             <@node display-image=false />


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172132788

Current:
<img width="247" alt="Screen Shot 2020-04-05 at 10 57 20 PM" src="https://user-images.githubusercontent.com/6343242/78519383-26044a00-7791-11ea-98ee-a0e355174d22.png">

New:
<img width="405" alt="Screen Shot 2020-04-05 at 10 58 28 PM" src="https://user-images.githubusercontent.com/6343242/78519382-256bb380-7791-11ea-9143-233584b2dbc5.png">

