### PR TITLE
Add section override with diagnostic feed block

### DIFF
--- a/sites/vehicleservicepros.com/server/routes/website-section.js
+++ b/sites/vehicleservicepros.com/server/routes/website-section.js
@@ -6,6 +6,7 @@ const queryFragment = require('@endeavor-business-media/package-shared/graphql/f
 const directory = require('../templates/website-section/directory');
 const section = require('../templates/website-section');
 const channel = require('../templates/website-section/channel');
+const diagnosticNetworkFeed = require('../templates/website-section/diagnostic-network-feed');
 const videos = require('../templates/website-section/videos');
 const blogs = require('../templates/website-section/blogs');
 
@@ -15,12 +16,21 @@ const channelAliases = [
   'vehicles',
   'distributors',
   'industry-news',
+  'diagnosticNetworkFeed',
 ];
 
 module.exports = (app) => {
   app.get('/:alias(leaders)', withWebsiteSection({
     template: leaders,
     queryFragment: leadersFragment,
+  }));
+  app.get('/:alias(in-the-bay)', withWebsiteSection({
+    template: diagnosticNetworkFeed,
+    queryFragment,
+  }));
+  app.get('/:alias(covid-19)', withWebsiteSection({
+    template: diagnosticNetworkFeed,
+    queryFragment,
   }));
   app.get('/:alias(blogs)', withWebsiteSection({
     template: blogs,

--- a/sites/vehicleservicepros.com/server/styles/index.scss
+++ b/sites/vehicleservicepros.com/server/styles/index.scss
@@ -30,10 +30,8 @@ $theme-site-header-breakpoints: (
       max-height: 200px;
     }
   }
-  .diagnostic-feed {
-    &__title {
-      @include theme-card-header();
-      padding: $marko-web-node-list-padding;
-    }
+  &__title {
+    @include theme-card-header();
+    padding: $marko-web-node-list-padding;
   }
 }

--- a/sites/vehicleservicepros.com/server/styles/index.scss
+++ b/sites/vehicleservicepros.com/server/styles/index.scss
@@ -33,5 +33,6 @@ $theme-site-header-breakpoints: (
   &__title {
     @include theme-card-header();
     padding: $marko-web-node-list-padding;
+    text-transform: uppercase;
   }
 }

--- a/sites/vehicleservicepros.com/server/styles/index.scss
+++ b/sites/vehicleservicepros.com/server/styles/index.scss
@@ -23,3 +23,17 @@ $theme-site-header-breakpoints: (
 );
 
 @import "../../node_modules/@endeavor-business-media/package-shared/scss/cygnus-skin";
+
+.with-diagnostic-feed {
+  .directory-facets {
+    &__list {
+      max-height: 200px;
+    }
+  }
+  .diagnostic-feed {
+    &__title {
+      @include theme-card-header();
+      padding: $marko-web-node-list-padding;
+    }
+  }
+}

--- a/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
@@ -57,7 +57,7 @@ $ const loadMore = {
         </div>
         <div class="mb-block diagnostic-feed">
           <h3 class="diagnostic-feed__title">
-            Disaster Support
+            DISASTER SUPPORT USER GROUP
           </h3>
           <iframe class="diagnostic-feed" frameborder="0" width="100%" height="300px" src="https://diag.net/g/disaster-support?e=1&hd=1" />
         </div>

--- a/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
@@ -56,8 +56,8 @@ $ const loadMore = {
           <directory-facets ...directory active-id=id />
         </div>
         <div class="mb-block">
-          <h3 class="diagnostic-feed__title">
-            DISASTER SUPPORT USER GROUP
+          <h3 class="with-diagnostic-feed__title">
+            Disaster Suppoert User Group
           </h3>
           <iframe frameborder="0" width="100%" height="300px" src="https://diag.net/g/disaster-support?e=1&hd=1" />
         </div>

--- a/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
@@ -1,0 +1,67 @@
+import { getAsObject, getAsArray } from "@base-cms/object-path";
+import { isFunction } from "@base-cms/utils";
+import queryFragment from "@endeavor-business-media/package-shared/graphql/fragments/content-list";
+import categories from "../../categories";
+
+$ const { GAM } = out.global;
+$ const { id, alias } = input;
+$ const adSlots = isFunction(input.adSlots) ? input.adSlots : ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
+});
+
+$ const directory = {
+  title: "Categories",
+  ...getAsObject(categories),
+  facets: categories,
+};
+
+$ const loadMore = {
+  queryParams: { limit: 14, skip: 9 },
+  ...getAsObject(input, "loadMore"),
+};
+
+<shared-website-section-page-default-layout
+  id=id
+  alias=alias
+  name=input.name
+  page-node=input.pageNode
+  ad-slots=adSlots
+  load-more=loadMore
+>
+  <@page>
+    <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+
+    <if(input.hero)>
+      <${input.hero} />
+    </if>
+    <else>
+      <shared-content-hero-block id=id />
+    </else>
+
+    <div class="row">
+      <div class="col-lg-4 mb-block">
+        <shared-website-section-list-block alias=alias>
+          <@query-params limit=4 skip=5 />
+          <@header>Latest</@header>
+        </shared-website-section-list-block>
+      </div>
+
+      <div class="col-lg-4 mb-block">
+        <shared-gam-display-ad id="gpt-ad-rail2" />
+      </div>
+
+      <div class="col-lg-4 with-diagnostic-feed">
+        <div class="mb-block">
+          <directory-facets ...directory active-id=id />
+        </div>
+        <div class="mb-block diagnostic-feed">
+          <h3 class="diagnostic-feed__title">
+            Disaster Support
+          </h3>
+          <iframe class="diagnostic-feed" frameborder="0" width="100%" height="300px" src="https://diag.net/g/disaster-support?e=1&hd=1" />
+        </div>
+      </div>
+    </div>
+  </@page>
+</shared-website-section-page-default-layout>

--- a/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
+++ b/sites/vehicleservicepros.com/server/templates/website-section/diagnostic-network-feed.marko
@@ -55,11 +55,11 @@ $ const loadMore = {
         <div class="mb-block">
           <directory-facets ...directory active-id=id />
         </div>
-        <div class="mb-block diagnostic-feed">
+        <div class="mb-block">
           <h3 class="diagnostic-feed__title">
             DISASTER SUPPORT USER GROUP
           </h3>
-          <iframe class="diagnostic-feed" frameborder="0" width="100%" height="300px" src="https://diag.net/g/disaster-support?e=1&hd=1" />
+          <iframe frameborder="0" width="100%" height="300px" src="https://diag.net/g/disaster-support?e=1&hd=1" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
This would only be on the COVID-19 & In The Bay sections

![Screen Shot 2020-04-08 at 10 52 58 AM](https://user-images.githubusercontent.com/3845869/78805572-2fef9e00-7987-11ea-8fb6-e8d5486c9b3e.png)

