### PR TITLE
Use channel layout on "covid-19" website section page

### DIFF
--- a/sites/firehouse.com/server/routes/website-section.js
+++ b/sites/firehouse.com/server/routes/website-section.js
@@ -23,6 +23,7 @@ const channelAliases = [
   'careers-education',
   'prevention-investigation',
   'stations',
+  'covid-19',
 ];
 
 module.exports = (app) => {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172184610

Page is too large of a screenshot to upload the whole page for change reviews, so only showing the top part of the page with the hero section now in place.

Current:
<img width="1164" alt="Screen Shot 2020-04-09 at 10 16 17 AM" src="https://user-images.githubusercontent.com/6343242/78904951-4ceda500-7a4b-11ea-8abc-4a66358c08b5.png">

New:
<img width="1215" alt="Screen Shot 2020-04-09 at 10 16 28 AM" src="https://user-images.githubusercontent.com/6343242/78904970-51b25900-7a4b-11ea-9501-8814f95647bc.png">



