### PR TITLE
Set Supplements page to use whitepaper template

### DIFF
--- a/packages/shared/components/layouts/website-section/feed.marko
+++ b/packages/shared/components/layouts/website-section/feed.marko
@@ -1,4 +1,5 @@
 import defaultDescription from "@base-cms/marko-web/utils/published-content/description";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 import { isFunction } from "@base-cms/utils";
 import queryFragment from "../../../graphql/fragments/content-list";
 
@@ -20,19 +21,21 @@ $ const adSlots = isFunction(input.adSlots) ? input.adSlots : ({ aliases }) => (
   <@page>
     <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
 
-    <marko-web-page-wrapper class="mb-block">
-      <@section>
-        <div class="row">
-          <div class="col">
-            <default-theme-breadcrumbs-with-home>
-              <@item>${name}</@item>
-            </default-theme-breadcrumbs-with-home>
-            <h1 class="page-wrapper__title">${name}</h1>
-            <div class="page-wrapper__deck">${description}</div>
+  <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-page-wrapper class="mb-block">
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-breadcrumbs-with-home>
+                <@item>${name}</@item>
+              </default-theme-breadcrumbs-with-home>
+              <h1 class="page-wrapper__title">${name}</h1>
+              <div class="page-wrapper__deck">${defaultValue(section.description, description)}</div>
+            </div>
           </div>
-        </div>
-      </@section>
-    </marko-web-page-wrapper>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
 
     <div class="row">
       <div class="col">

--- a/packages/shared/components/layouts/website-section/feed.marko
+++ b/packages/shared/components/layouts/website-section/feed.marko
@@ -21,8 +21,8 @@ $ const adSlots = isFunction(input.adSlots) ? input.adSlots : ({ aliases }) => (
   <@page>
     <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
 
-  <marko-web-resolve-page|{ data: section }| node=pageNode>
-      <marko-web-page-wrapper class="mb-block">
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+        <marko-web-page-wrapper class="mb-block">
         <@section>
           <div class="row">
             <div class="col">

--- a/packages/shared/components/layouts/website-section/feed.marko
+++ b/packages/shared/components/layouts/website-section/feed.marko
@@ -22,7 +22,7 @@ $ const adSlots = isFunction(input.adSlots) ? input.adSlots : ({ aliases }) => (
     <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
 
     <marko-web-resolve-page|{ data: section }| node=pageNode>
-        <marko-web-page-wrapper class="mb-block">
+      <marko-web-page-wrapper class="mb-block">
         <@section>
           <div class="row">
             <div class="col">

--- a/sites/mswmanagement.com/config/navigation.js
+++ b/sites/mswmanagement.com/config/navigation.js
@@ -14,7 +14,7 @@ module.exports = {
       { href: '/magazine', label: 'Magazine ' },
       { href: '/page/advertise', label: 'Advertise' },
       { href: '/white-papers', label: 'Free Reports' },
-      { href: '/page/supplements', label: 'Supplements' },
+      { href: 'supplements', label: 'Supplements' },
     ],
   },
   tertiary: {
@@ -48,7 +48,7 @@ module.exports = {
       items: [
         { href: '/magazine', label: 'Magazine' },
         { href: '/white-papers', label: 'Free Reports' },
-        { href: '/page/supplements', label: 'Supplements' },
+        { href: '/supplements', label: 'Supplements' },
       ],
     },
     {

--- a/sites/mswmanagement.com/config/navigation.js
+++ b/sites/mswmanagement.com/config/navigation.js
@@ -14,7 +14,7 @@ module.exports = {
       { href: '/magazine', label: 'Magazine ' },
       { href: '/page/advertise', label: 'Advertise' },
       { href: '/white-papers', label: 'Free Reports' },
-      { href: 'supplements', label: 'Supplements' },
+      { href: '/supplements', label: 'Supplements' },
     ],
   },
   tertiary: {

--- a/sites/mswmanagement.com/server/routes/website-section.js
+++ b/sites/mswmanagement.com/server/routes/website-section.js
@@ -3,7 +3,6 @@ const leadersFragment = require('@endeavor-business-media/package-leaders/graphq
 const leaders = require('@endeavor-business-media/package-shared/templates/website-section/leaders');
 const contactUs = require('@endeavor-business-media/package-shared/templates/website-section/contact-us');
 const queryFragment = require('@endeavor-business-media/package-shared/graphql/fragments/website-section-page');
-
 const directory = require('../templates/website-section/directory');
 const section = require('../templates/website-section');
 const whitePapers = require('../templates/website-section/white-papers');
@@ -26,6 +25,10 @@ module.exports = (app) => {
     queryFragment,
   }));
   app.get('/:alias(white-papers)', withWebsiteSection({
+    template: whitePapers,
+    queryFragment,
+  }));
+  app.get('/:alias(supplements)', withWebsiteSection({
     template: whitePapers,
     queryFragment,
   }));


### PR DESCRIPTION
Also added supplements to navigation

https://www.pivotaltracker.com/story/show/172232210

Would use custom text:
<img width="1282" alt="Screen Shot 2020-04-09 at 3 57 53 PM" src="https://user-images.githubusercontent.com/6343242/78937265-301e9500-7a7e-11ea-8098-5f877518dd4d.png">

<img width="1213" alt="Screen Shot 2020-04-09 at 3 59 49 PM" src="https://user-images.githubusercontent.com/6343242/78937207-11200300-7a7e-11ea-807f-fe4fa649c8dd.png">

Would use default text:
<img width="1306" alt="Screen Shot 2020-04-09 at 3 58 30 PM" src="https://user-images.githubusercontent.com/6343242/78937216-14b38a00-7a7e-11ea-9015-d8f3cbe63372.png">

<img width="590" alt="Screen Shot 2020-04-09 at 4 22 26 PM" src="https://user-images.githubusercontent.com/6343242/78937336-53494480-7a7e-11ea-8a8e-2f4dbc975344.png">

