### PR TITLE
Add Conference link to nav

### DIFF
--- a/sites/rdhmag.com/config/navigation.js
+++ b/sites/rdhmag.com/config/navigation.js
@@ -14,6 +14,7 @@ module.exports = {
     items: [
       { href: '/page/about-us', label: 'About Us' },
       { href: '/job-postings', label: 'Career Center' },
+      { href: 'https://www.rdhunderoneroof.com/', label: 'Conference', target: '_blank' },
       { href: 'https://dentalacademyofce.com/default.aspx', label: 'Earn CE', target: '_blank' },
       { href: 'https://www.dentistryiq.com/products/free-samples', label: 'Free Samples', target: '_blank' },
       { href: '/magazine', label: 'Magazine' },
@@ -52,6 +53,7 @@ module.exports = {
     {
       label: 'Resources',
       items: [
+        { href: 'https://www.rdhunderoneroof.com/', label: 'Conference', target: '_blank' },
         { href: 'https://dentalacademyofce.com/default.aspx', label: 'Earn CE', target: '_blank' },
         { href: 'https://www.dentistryiq.com/products/free-samples', label: 'Free Samples', target: '_blank' },
         { href: '/job-postings', label: 'Career Center' },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172335427

Added "Conference" link to RDH secondary and hamburger navs

New:
<img width="865" alt="Screen Shot 2020-04-15 at 1 11 49 PM" src="https://user-images.githubusercontent.com/6343242/79366825-d7864680-7f1a-11ea-8fa2-8b1d14e0c1ab.png">

<img width="275" alt="Screen Shot 2020-04-15 at 1 11 58 PM" src="https://user-images.githubusercontent.com/6343242/79366824-d7864680-7f1a-11ea-936b-19c4308e8c32.png">

