### PR TITLE
Move leaderboard ad to the top of home page

### DIFF
--- a/sites/plasticsmachinerymagazine.com/server/templates/index.marko
+++ b/sites/plasticsmachinerymagazine.com/server/templates/index.marko
@@ -15,9 +15,9 @@ $ const adSlots = ({ aliases }) => ({
   ad-slots=adSlots
 >
   <@page>
-    <shared-content-hero-block id=id />
-
     <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+
+    <shared-content-hero-block id=id />
 
     <div class="row">
       <div class="col-lg-4 mb-block">


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172388416

Current:
<img width="1228" alt="Screen Shot 2020-04-20 at 11 46 27 AM" src="https://user-images.githubusercontent.com/6343242/79772234-d62f9200-82fd-11ea-9a3f-1833afa394f6.png">


New:
<img width="1235" alt="Screen Shot 2020-04-20 at 11 55 02 AM" src="https://user-images.githubusercontent.com/6343242/79772246-da5baf80-82fd-11ea-90cd-aab3ba506e56.png">
