### PR TITLE
Change title for webinar templates

### DIFF
--- a/sites/gxcontractor.com/server/routes/published-content.js
+++ b/sites/gxcontractor.com/server/routes/published-content.js
@@ -4,6 +4,6 @@ const videos = require('@endeavor-business-media/package-shared/templates/publis
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
-  app.get('/webinars', (_, res) => { res.marko(webinars); });
+  app.get('/webinars', (_, res) => { res.marko(webinars, { title: 'Webinars' }); });
   app.get('/videos', (_, res) => { res.marko(videos); });
 };


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172747515

Changed from "Webcasts" to "Webinars"

<img width="625" alt="Screen Shot 2020-05-13 at 4 58 35 PM" src="https://user-images.githubusercontent.com/6343242/81864938-49ae7300-953b-11ea-82ae-7f75c6a9cdd8.png">
