### PR TITLE
Add ‘Cannabis Security’ channel

### DIFF
--- a/sites/securityinfowatch.com/config/navigation.js
+++ b/sites/securityinfowatch.com/config/navigation.js
@@ -13,10 +13,11 @@ module.exports = {
   },
   secondary: {
     items: [
+      { href: '/advertise', label: 'Advertise' },
+      { href: '/subscribe', label: 'Subscribe' },
       { href: 'https://forums.securityinfowatch.com', label: 'Forums', target: '_blank' },
       { href: '/directory', label: 'Buyer\'s Guide' },
-      { href: '/subscribe', label: 'Subscribe' },
-      { href: '/advertise', label: 'Advertise' },
+      { href: '/cannabis-security', label: 'Cannabis Security' },
     ],
   },
   tertiary: {
@@ -47,6 +48,7 @@ module.exports = {
         { href: '/cybersecurity', label: 'Cybersecurity' },
         { href: '/covid-19', label: 'COVID-19' },
         { href: '/perimeter-security', label: 'Perimeter Security' },
+        { href: '/cannabis-security', label: 'Cannabis Security' },
       ],
     },
     {

--- a/sites/securityinfowatch.com/server/routes/website-section.js
+++ b/sites/securityinfowatch.com/server/routes/website-section.js
@@ -18,6 +18,7 @@ const channelAliases = [
   'alarms-monitoring',
   'cybersecurity',
   'perimeter-security',
+  'cannabis-security',
 ];
 
 module.exports = (app) => {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172825631

- Add ‘Cannabis Security’ to channel template list
- Add CS to Topics and Secondary Nav
- Reorder Secondary Nav

Current:
<img width="496" alt="Screen Shot 2020-05-15 at 11 46 50 AM" src="https://user-images.githubusercontent.com/6343242/82069790-d4a97d80-96a1-11ea-93fc-75a9811ed3d5.png">

New:
![Screen Shot 2020-05-15 at 11 46 37 AM](https://user-images.githubusercontent.com/6343242/82069803-da06c800-96a1-11ea-98e0-1402c706ae1b.png)
![Screen Shot 2020-05-15 at 11 46 28 AM](https://user-images.githubusercontent.com/6343242/82069806-da9f5e80-96a1-11ea-89ec-05d195b3163a.png)
