### PR TITLE
Change “Sponsored Content” title back to "Summits"

### DIFF
--- a/sites/hcinnovationgroup.com/server/templates/index.marko
+++ b/sites/hcinnovationgroup.com/server/templates/index.marko
@@ -26,7 +26,7 @@ $ const adSlots = ({ aliases }) => ({
         <marko-web-query|{ node }| name="content" params={ id: 21069218, queryFragment: summitsQueryFragment }>
           <div class="node-list">
             <marko-web-node-list-header>
-              <marko-web-link href="/zzsummits/article/21069218/sponsored-content">Sponsored Content</marko-web-link>
+              <marko-web-link href="/zzsummits/article/21069218/sponsored-content">Summits</marko-web-link>
             </marko-web-node-list-header>
             <marko-web-node
               type=`${node.type}-content`


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172948976

Brand decided to revert the change made previously in https://github.com/base-cms-websites/endeavor-business-media/pull/464