### PR TITLE
Ensure there is more than one image when displaying button

### DIFF
--- a/packages/shared/components/content-page/contents.marko
+++ b/packages/shared/components/content-page/contents.marko
@@ -40,7 +40,7 @@ $ const accessLevels = getAsArray(content, "userRegistration.accessLevels");
         width=720
         obj=content.primaryImage
       />
-      <if(images.length && displayPhotoswipe)>
+      <if(images.length && images.length > 1 && displayPhotoswipe)>
         <button class="btn btn-primary mb-3" data-gallery-button="true">View Image Gallery</button>
       </if>
     </else>


### PR DESCRIPTION
Setup the media gallery button to only display if there is more than one image to display.  You can still click on any of the image to display it full screen though.

![Screen Shot 2020-06-15 at 10 45 52 AM](https://user-images.githubusercontent.com/3845869/84678298-75839680-aef5-11ea-9893-920710e5beea.png)
![Screen Shot 2020-06-15 at 10 46 01 AM](https://user-images.githubusercontent.com/3845869/84678305-79171d80-aef5-11ea-875b-46023961fe34.png)
