### PR TITLE
Update single link sub to use dragonform reference

### DIFF
--- a/sites/bioopticsworld.com/server/templates/subscribe/index.marko
+++ b/sites/bioopticsworld.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=BOWPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/broadbandtechreport.com/server/templates/subscribe/index.marko
+++ b/sites/broadbandtechreport.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=BTRPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/cablinginstall.com/server/templates/subscribe/index.marko
+++ b/sites/cablinginstall.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=CIMPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/distributedenergy.com/server/templates/subscribe/index.marko
+++ b/sites/distributedenergy.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=DE_eNLshort" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/evaluationengineering.com/server/templates/subscribe/index.marko
+++ b/sites/evaluationengineering.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=EE_eNLshort&version=1&page=1" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/flowcontrolnetwork.com/server/templates/subscribe/index.marko
+++ b/sites/flowcontrolnetwork.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://end.dragonforms.com/loading.do?omedasite=END13_YFland" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/gxcontractor.com/server/templates/subscribe/index.marko
+++ b/sites/gxcontractor.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=GXC_eNLshort" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/industrial-lasers.com/server/templates/subscribe/index.marko
+++ b/sites/industrial-lasers.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=ILSPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/intelligent-aerospace.com/server/templates/subscribe/index.marko
+++ b/sites/intelligent-aerospace.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=IAPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/laserfocusworld.com/server/templates/subscribe/index.marko
+++ b/sites/laserfocusworld.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=LFWPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/militaryaerospace.com/server/templates/subscribe/index.marko
+++ b/sites/militaryaerospace.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=MAEPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/mswmanagement.com/server/templates/subscribe/index.marko
+++ b/sites/mswmanagement.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=MSW_eNLshort" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/perioimplantadvisory.com/server/templates/subscribe/index.marko
+++ b/sites/perioimplantadvisory.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -9,7 +10,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://formdesigner.ecn5.com/GetForm?tokenuid=a56c9d44-88f6-452a-9f61-92d48166c3a9" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/processingmagazine.com/server/templates/subscribe/index.marko
+++ b/sites/processingmagazine.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://end.dragonforms.com/loading.do?omedasite=END14_PBnew" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/vision-systems.com/server/templates/subscribe/index.marko
+++ b/sites/vision-systems.com/server/templates/subscribe/index.marko
@@ -1,4 +1,5 @@
 $ const { config } = out.global;
+$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
@@ -8,7 +9,14 @@ $ const { config } = out.global;
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href="https://endeavor.dragonforms.com/loading.do?omedasite=VSDPrefPage" target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>

--- a/sites/watertechonline.com/server/templates/subscribe/index.marko
+++ b/sites/watertechonline.com/server/templates/subscribe/index.marko
@@ -9,7 +9,14 @@ $ const dragonForms = require('../../../config/dragon-forms');
       <div class="col">
         <h4>Newsletters</h4>
         <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
-        <p><strong><marko-web-link href=dragonForms.getFormUrl('newsletterSubscribe') target="_blank">Subscribe / Manage Preferences</marko-web-link></strong></p>
+        <p>
+          <marko-web-link
+            class="font-weight-bold"
+            href=dragonForms.getFormUrl('newsletterSignup')
+            target="_blank">
+            Subscribe / Manage Preferences
+          </marko-web-link>
+        </p>
         <hr>
       </div>
     </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173476669

Goal: dragon forms can be updated in one place “/config/dragon-forms” instead of across each template using a dragon form.