### PR TITLE
GAM lazy loading

### DIFF
--- a/packages/gam-prestitial/package.json
+++ b/packages/gam-prestitial/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/object-path": "^1.25.0"
   }
 }

--- a/packages/shared/components/document.marko
+++ b/packages/shared/components/document.marko
@@ -31,7 +31,9 @@ $ const isRadixEnabled = Boolean(radix.enabled && radix.appId);
     <${input.head} />
     <marko-web-gtm-start />
     <if(GAM)>
-      <marko-web-gam-enable />
+      <marko-web-gam-enable>
+        <@lazy-load ...site.getAsObject("gam.lazyLoad") />
+      </marko-web-gam-enable>
       <marko-web-gam-targeting key-values={ uri: req.path } />
     </if>
   </@head>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
     "@base-cms/image": "^1.6.3",
     "@base-cms/marko-core": "^1.26.2",
     "@base-cms/marko-web": "^1.29.10",
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/marko-web-gcse": "^1.25.0",
     "@base-cms/marko-web-gtm": "^1.25.0",
     "@base-cms/marko-web-icons": "^1.29.6",

--- a/sites/officer.com/config/gam.js
+++ b/sites/officer.com/config/gam.js
@@ -2,6 +2,13 @@ const configureGAM = require('@endeavor-business-media/package-shared/config/gam
 
 const config = configureGAM({ basePath: 'Officer' });
 
+config.lazyLoad = {
+  enabled: false, // set to true to enable lazy loading
+  fetchMarginPercent: 100, // fetch ad when one viewport away
+  renderMarginPercent: 50, // render ad when half viewport away
+  mobileScaling: 2, // double these on mobile
+};
+
 config
   .setTemplate('LB1', {
     size: [[970, 250], [970, 90], [970, 66], [728, 90], [320, 50], [300, 50], [300, 100]],

--- a/sites/offshore-mag.com/package.json
+++ b/sites/offshore-mag.com/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@base-cms/marko-core": "^1.26.2",
     "@base-cms/marko-web": "^1.29.10",
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/marko-web-gcse": "^1.25.0",
     "@base-cms/marko-web-gtm": "^1.25.0",
     "@base-cms/marko-web-icons": "^1.29.6",

--- a/sites/offshore-mag.com/server/components/document.marko
+++ b/sites/offshore-mag.com/server/components/document.marko
@@ -13,7 +13,9 @@ $ const { site, req } = out.global;
     <marko-web-native-x-init uri=nativeX.getUri() enabled=nativeX.isEnabled() />
     <${input.head} />
     <marko-web-gtm-start />
-    <marko-web-gam-enable />
+    <marko-web-gam-enable>
+      <@lazy-load ...site.getAsObject("gam.lazyLoad") />
+    </marko-web-gam-enable>
     <marko-web-gam-targeting key-values={ uri: req.path } />
   </@head>
   <@above-container>

--- a/sites/strategies-u.com/package.json
+++ b/sites/strategies-u.com/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@base-cms/marko-core": "^1.26.2",
     "@base-cms/marko-web": "^1.29.10",
-    "@base-cms/marko-web-gam": "^1.25.10",
+    "@base-cms/marko-web-gam": "^1.30.0",
     "@base-cms/marko-web-gcse": "^1.25.0",
     "@base-cms/marko-web-gtm": "^1.25.0",
     "@base-cms/marko-web-icons": "^1.29.6",

--- a/sites/strategies-u.com/server/components/document.marko
+++ b/sites/strategies-u.com/server/components/document.marko
@@ -13,7 +13,9 @@ $ const { site, req } = out.global;
     <marko-web-native-x-init uri=nativeX.getUri() enabled=nativeX.isEnabled() />
     <${input.head} />
     <marko-web-gtm-start />
-    <marko-web-gam-enable />
+    <marko-web-gam-enable>
+      <@lazy-load ...site.getAsObject("gam.lazyLoad") />
+    </marko-web-gam-enable>
     <marko-web-gam-targeting key-values={ uri: req.path } />
   </@head>
   <@above-container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -828,10 +828,10 @@
     moment "^2.24.0"
     moment-timezone "^0.5.26"
 
-"@base-cms/marko-web-gam@^1.25.10":
-  version "1.25.10"
-  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.25.10.tgz#f40f44f4d68ebab4c51d8ce0b42efc139bd618ee"
-  integrity sha512-QC2UaGQaozbrElM2mjaNpuEL+3ifKkRStOIv3/jn1yd4jVuUv6m8bbtfDOpNxEF0+66e6aFWVCnVOlqPwDjfxQ==
+"@base-cms/marko-web-gam@^1.30.0":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-gam/-/marko-web-gam-1.30.0.tgz#c949b6cf651d26e93d71d8bacee4821c6a4af660"
+  integrity sha512-0GKAE0NMs9xmzkH4ejxgRZyEmNhhn9cHOXNrsEqJImE2EGakMvsM8cgufgzdawpvh7tmVZKRPhjPaX5RrGnssQ==
   dependencies:
     "@base-cms/object-path" "^1.25.0"
     "@base-cms/utils" "^1.25.0"


### PR DESCRIPTION
Add support for lazy loading of ads. This is disabled by default and can be enabled/configured within each site config. An example configuration (though disabled) was added to Officer.

See `sites/officer.com/config/site.js` for a configuration example.