### PR TITLE
DIQ template changes for index, subscribe, and nav

### DIFF
--- a/sites/dentistryiq.com/config/navigation.js
+++ b/sites/dentistryiq.com/config/navigation.js
@@ -53,7 +53,6 @@ module.exports = {
       label: 'Resources',
       items: [
         { href: '/front-office/office-forms', label: 'Front Office Forms' },
-        { href: '/magazine', label: 'Magazine' },
         { href: '/videos', label: 'Videos' },
         { href: '/white-papers', label: 'White Papers' },
         { href: '/webcasts', label: 'Webcasts' },

--- a/sites/dentistryiq.com/server/routes/website-section.js
+++ b/sites/dentistryiq.com/server/routes/website-section.js
@@ -17,7 +17,7 @@ module.exports = (app) => {
     template: contactUs,
     queryFragment,
   }));
-  app.get('/:alias(products/free-samples)', withWebsiteSection({
+  app.get('/:alias(dentistry/products/free-samples)', withWebsiteSection({
     template: freeSamplesTemplate,
     queryFragment,
   }));

--- a/sites/dentistryiq.com/server/templates/index.marko
+++ b/sites/dentistryiq.com/server/templates/index.marko
@@ -62,7 +62,7 @@ $ const { id, alias, name, pageNode } = data;
         </shared-website-section-list-block>
       </div>
       <div class="col-lg-4 mb-block">
-        <shared-website-section-list-block alias="products">
+        <shared-website-section-list-block alias="dental-jobs">
           <@query-params limit=3 />
           <@native-x index=2 />
         </shared-website-section-list-block>

--- a/sites/dentistryiq.com/server/templates/subscribe/index.marko
+++ b/sites/dentistryiq.com/server/templates/subscribe/index.marko
@@ -54,7 +54,8 @@ $ const dragonForms = require('../../../config/dragon-forms');
           <p class="page-wrapper__description">
             <em>DentistryIQ</em> partners with <em>Dental Economics</em> and <em>RDH magazine</em> to provide timely information for dental professionals. Subscribe to these leading publications today!
           </p>
-          <a class="btn btn-primary" href="/magazine">See Dental Magazines</a>
+          <p><a class="btn btn-primary" href="https://www.dentaleconomics.com/subscribe">Subscribe to Dental Economics Magazine</a></p>
+          <p><a class="btn btn-primary" href="http://www.rdhmag.com/subscribe">Subscribe to RDH Magazine</a></p>
         </div>
       </div>
     </div>

--- a/sites/dentistryiq.com/server/templates/subscribe/index.marko
+++ b/sites/dentistryiq.com/server/templates/subscribe/index.marko
@@ -2,44 +2,44 @@ $ const { config } = out.global;
 $ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
-  description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
+  description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms, including print, online, email, and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
 >
   <@newsletter-section>
     <div class="row">
       <div class="col">
         <h4>Newsletters</h4>
-            <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
+            <p>Stay up-to-date on industry news and events, new product launches, and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you.</p>
             <h5>Dental Economics Newsletters</h5>
             <p class="page-wrapper__description">
               <a class="btn btn-primary" href=dragonForms.getFormUrl('newsletterSubscribe')>Subscribe to Dental Economics Newsletters</a>
             </p>
             <div class="page-wrapper__body">
-              <p><strong>Breakthrough Clinical</strong> - It’s easy to get into a clinical rut. But why stay that way? You can grow and you can change! Dr. Stacey Gividen, a general dentist—and an elite athlete—is here to help. Each month, Dr. Gividen gathers exclusive, insightful, and motivational articles that will reignite your passion for the clinical specialties. Consider this newsletter your new clinical personal trainer!</p>
+              <p><strong>Chairside Daily</strong> - This daily newsletter provides case studies and product information to help you expand your clinical acumen. The newsletter is directed by Stacey Gividen, DDS, and Pamela Maragliano-Muniz, DMD.</p>
 
-              <p><strong>DE's Principles of Practice Management</strong> - There’s a lot of practice management mumbo jumbo out there. But that kind of thing is not allowed here! In this bimonthly newsletter, Dental Economics Chief Editor Dr. Chris Salierno presents handpicked articles that will light a fire under your practice's ROI. It’s exclusive, expert business advice you don’t want to miss.</p>
+              <p><strong>DE's Principles of Practice Management</strong> - There’s a lot of practice management mumbo jumbo out there. But that kind of thing is not allowed here! In this bimonthly newsletter, Dental Economics Chief Editor Chris Salierno, DDS, presents handpicked articles that will light a fire under your practice's ROI. It’s exclusive, expert business advice you don’t want to miss.</p>
 
-              <p><strong>Dental Assisting Digest (DAD)</strong> - the monthly newsletter designed specifically for dental assistants, whose contributions to dental practices keep things running smoothly. Under the guidance of Editorial Director Tija Hunter, CDA, EFDA, DAD keeps assistants up-to-date on the latest clinical tips and techniques, as well as provides information designed to empower assistants at every stage of their careers.</p>
+              <p><strong>Dental Assisting Digest</strong> - the monthly newsletter designed specifically for dental assistants, whose contributions to dental practices keep things running smoothly. Under the guidance of Editorial Director Tija Hunter, CDA, EFDA, this newsletter keeps assistants up-to-date on the latest clinical tips and techniques, as well as provides information designed to empower assistants at every stage of their careers.</p>
 
-              <p><strong>Dental Academy of Continuing Education</strong> - They say knowledge is power, so how knowledgeable are you? Get smarter with the help of the Dental Academy of Continuing Education newsletter! Each month, Dental Academy of Continuing Education partners with Dental Economics, DentistryIQ, and RDH magazine to present awesome continuing education opportunities—often at discounted prices...or even free! Editorial Director Pamela Maragliano-Muniz, DMD FACP, also gives you CE tips, CE advice, and his personal CE picks. There’s no better value in CE—find out why today!</p>
+              <p><strong>Dental Academy of Continuing Education</strong> - They say knowledge is power, so how knowledgeable are you? Get smarter with the help of the Dental Academy of Continuing Education newsletter! Each month, Dental Academy of Continuing Education partners with Dental Economics, DentistryIQ, and RDH magazine to present awesome continuing education opportunities—often at discounted prices...or even for free! Editorial Director Pamela Maragliano-Muniz, DMD, also gives you CE tips, CE advice, and her personal CE picks. There’s no better value in CE—find out why today!</p>
 
-              <p><strong>Dental Office Manager Digest (DOMD)</strong> - giftwraps exclusive articles for an integral part of the dental team—office managers. Each month, editorial director Kyle Summerford, an office manager himself, presents the best exclusive articles for the people who keep things running smoothly. It’s cutting-edge information office managers won’t want to miss. Join our growing list of subscribers and take your career to the next level today!</p>
+              <p><strong>Dental Office Manager Digest</strong> - This newsletter giftwraps exclusive articles for an integral part of the dental team—office managers. Each month, editorial director Kyle Summerford, an office manager himself, presents the best exclusive articles for dental office managers. It’s cutting-edge information office managers won’t want to miss. Join our growing list of subscribers and take your career to the next level today!</p>
 
-              <p><strong>Group Practice and DSO Digest</strong> - If you're interested in the growing trend of practice consolidation or becoming part of a DSO, this e-newsletter from DentistryIQ and Dental Economics is for you. Every month we’ll bring you critical content on the opportunities and challenges of operating multiple dental practices. Whether you’re an entrepreneurial dentist who dreams of expanding to new locations, or you’re a well-established DSO, we're here to help.</p>
+              <p><strong>Dental Workforce Update</strong> - This monthly newsletter provides updates on dental practice staffing solutions, human resources, and career development for dental professionals.</p>
+
+              <p><strong>Group Practice and DSO Digest</strong> - If you're interested in the growing trend of practice consolidation or becoming part of a DSO, this newsletter from DentistryIQ and Dental Economics is for you. Every month we’ll bring you critical content on the opportunities and challenges of operating multiple dental practices. Whether you’re an entrepreneurial dentist who dreams of expanding to new locations or you’re a well-established DSO, we're here to help.</p>
 
               <p><strong>Morning Briefing</strong> - This daily newsletter keeps you current on the latest developments in dentistry, including those related to the coronavirus pandemic. It combines the resources of <em>Dental Economics, DentistryIQ, Perio-Implant Advisory,</em> and <em>RDH magazine.</em></p>
 
-              <p><strong>Pearls for Your Practice: The Product Navigator</strong> - Whether you’re a dentist or a dental hygienist, it can be tricky to navigate the world of dental products—new ones are always becoming available. Plus, how can you know what really works? Well, consider newsletter your new best friend. You'll learn about the latest products to hit the market, be in-the-know when your favorite products are upgraded, and brush up on your clinical techniques. Plus, you’ll get expert product reviews, case studies, demonstration videos, advice articles, and more. Come aboard the Product Navigator today!</p>
-
-              <p><strong>Perio-Implant Advisory</strong> - focuses on issues relating to periodontal and implant medicine. Editorial Director Scott Froum, DDS, brings an unbiased clinical and academic perspective to the world of dental implants, periodontics, restorative dentistry, surgical technique, and practice management. Articles cover case studies in complex care and how to solve clinical complications with a team-based approach through interdisciplinary management. Perio-Implant Advisory is a chairside resource for the entire dental team.</p>
+              <p><strong>Perio-Implant Advisory</strong> - This newsletter focuses on issues relating to periodontal and implant medicine. Editorial Director Scott Froum, DDS, brings an unbiased clinical and academic perspective to the world of dental implants, periodontics, restorative dentistry, surgical technique, and practice management. Articles cover case studies in complex care and how to solve clinical complications with a team-based approach through interdisciplinary management. Perio-Implant Advisory is a chairside resource for the entire dental team.</p>
             </div>
             <h5>RDH Newsletters</h5>
             <p class="page-wrapper__description">
               <a class="btn btn-primary" href="https://endeavor.dragonforms.com/loading.do?omedasite=RDHnewpref">Subscribe to RDH Newsletters</a>
             </p>
             <div class="page-wrapper__body">
-              <p><strong>RDH eVillage</strong> - provides content dedicated to the RDH professional. Articles will provide clinical tips, product and technique information, career advice, industry updates, opportunities to become more involved in the RDH community, and trending topics. Chief Editor Jackie Sanders, MBA, RDH, combines insightful and pertinent content which will motivate and inspire you to want more.</p>
+              <p><strong>RDH eVillage</strong> - This weekly newsletter provides content dedicated to the RDH professional. Articles will provide clinical tips, product and technique information, career advice, industry updates, opportunities to become more involved in the RDH community, and trending topics. Chief Editor Jackie Sanders, MBA, RDH, combines insightful and pertinent content which will motivate and inspire you to want more.</p>
 
-              <p><strong>RDH Graduate</strong> - designed specifically for the dental hygiene student and the new dental hygienist, who is filled with energy and excitement yet still wants to learn more. Editorial Director Amber Auger MPH, RDH, gathers content that will answer many of the new professionals’ questions while inspiring them to ask the necessary questions.</p>
+              <p><strong>RDH Graduate</strong> - This newsletter is designed specifically for the dental hygiene student and the new dental hygienist, who is filled with energy and excitement yet still wants to learn more. Editorial Director Amber Auger MPH, RDH, gathers content that will answer many of the new professionals’ questions while inspiring them to ask the necessary questions.</p>
             </div>
         <hr>
       </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173596261

1) Added individual buttons for RDH and DE magazines on "Magazines" section of DIQ /subscribe page

![Screen Shot 2020-07-07 at 12 05 36 PM](https://user-images.githubusercontent.com/6343242/86809778-3a830780-c04a-11ea-8687-996969e845ae.png)

2) Removed /magazine link from the hamburger nav

3) Corrected route for moving page "Free Samples" which is linked from the secondary navigation

4) Updated "Products" alias block on homepage to "Dental Jobs"
![Screen Shot 2020-07-07 at 12 08 45 PM](https://user-images.githubusercontent.com/6343242/86810160-a1082580-c04a-11ea-9623-2ab6b5ce306a.png)

5) Made requested updates to the text of the newsletter descriptions
