### PR TITLE
New ad alias and nav updates for OS

### DIFF
--- a/sites/offshore-mag.com/config/gam.js
+++ b/sites/offshore-mag.com/config/gam.js
@@ -120,6 +120,14 @@ config
     { name: 'rail2', templateName: 'RAIL2', path: 'business-briefs/rail2' },
     { name: 'load-more', templateName: 'LM', path: 'business-briefs/load-more' },
     { name: 'reskin', path: 'business-briefs/reskin' },
+  ])
+  .setAliasAdUnits('renewable-energy', [
+    { name: 'lb1', templateName: 'LB1', path: 'renewable-energy/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'renewable-energy/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'renewable-energy/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'renewable-energy/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'renewable-energy/load-more' },
+    { name: 'reskin', path: 'renewable-energy/reskin' },
   ]);
 
 module.exports = config;

--- a/sites/offshore-mag.com/config/navigation.js
+++ b/sites/offshore-mag.com/config/navigation.js
@@ -55,6 +55,7 @@ module.exports = {
         { href: '/rigs-vessels', label: 'Rigs/Vessels' },
         { href: '/deepwater', label: 'Deepwater' },
         { href: '/business-briefs', label: 'Business Briefs' },
+        { href: '/renewable-energy', label: 'Renewable Energy' },
       ],
     },
     {
@@ -66,6 +67,7 @@ module.exports = {
         { href: '/white-papers', label: 'White Papers' },
         { href: '/webcasts', label: 'Webcasts' },
         { href: '/events', label: 'Events' },
+        { href: '/surveys', label: 'Surveys' },
       ],
     },
     {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/173951561

- Setup ad alias for /renewable-energy ad placements
- Add 'Surveys' and 'Renewable Energy' to the ham nav menu, as requested

<img width="131" alt="Screen Shot 2020-07-27 at 10 33 23 AM" src="https://user-images.githubusercontent.com/6343242/88554679-cc9c8100-cff4-11ea-9416-d4c72355015a.png">
