### PR TITLE
Global thought leaders page.

### DIFF
--- a/sites/watertechonline.com/server/graphql/fragments/global-thought-leaders.js
+++ b/sites/watertechonline.com/server/graphql/fragments/global-thought-leaders.js
@@ -1,0 +1,44 @@
+const gql = require('graphql-tag');
+
+module.exports = gql`
+
+fragment GlobalThoughtLeadersContentFragment on Content {
+  id
+  type
+  name
+  siteContext {
+    path
+  }
+  ... on ContentCompany {
+    primaryImage {
+      id
+      src
+      alt
+      isLogo
+    }
+  }
+  ... on ContentVideo {
+    embedCode
+    company {
+      id
+      name
+      siteContext {
+        path
+      }
+      primaryImage {
+        id
+        src
+        alt
+        isLogo
+      }
+    }
+  }
+  ... on ContentWhitepaper {
+    body
+    company {
+      id
+      name
+    }
+  }
+}
+`;

--- a/sites/watertechonline.com/server/routes/website-section.js
+++ b/sites/watertechonline.com/server/routes/website-section.js
@@ -8,6 +8,7 @@ const directory = require('../templates/website-section/directory');
 const section = require('../templates/website-section');
 const whitePapers = require('../templates/website-section/white-papers');
 const industryTemplate = require('../templates/website-section/industry');
+const globalThoughtLeaders = require('../templates/website-section/global-thought-leaders');
 
 module.exports = (app) => {
   app.get('/:alias(leaders)', withWebsiteSection({
@@ -24,6 +25,10 @@ module.exports = (app) => {
   }));
   app.get('/:alias(directory/[a-z0-9-/]+)', withWebsiteSection({
     template: directory,
+    queryFragment,
+  }));
+  app.get('/:alias(global-thought-leaders)', withWebsiteSection({
+    template: globalThoughtLeaders,
     queryFragment,
   }));
   app.get('/:alias(white-papers)', withWebsiteSection({

--- a/sites/watertechonline.com/server/templates/website-section/global-thought-leaders.marko
+++ b/sites/watertechonline.com/server/templates/website-section/global-thought-leaders.marko
@@ -1,0 +1,147 @@
+import { get } from '@base-cms/object-path';
+import queryFragment from "../../graphql/fragments/global-thought-leaders";
+
+$ const { GAM } = out.global;
+$ const { id, alias, name, pageNode } = data;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+});
+
+$ const imageOpts = {
+  fit: "fillmax",
+  fillColor: "fff",
+  h: 180,
+  w: 320,
+};
+
+<shared-website-section-page-default-layout
+  id=id
+  alias=alias
+  name=name
+  page-node=pageNode
+  ad-slots=adSlots
+>
+  <@page>
+    <shared-gam-display-ad id="gpt-ad-lb1" modifiers=["top-of-page"] />
+
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <default-theme-website-section-breadcrumbs section=section />
+              <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
+            </div>
+          </div>
+        </@section>
+        <@section>
+          <div class="row">
+            <marko-web-query|{ nodes }|
+              name="website-scheduled-content"
+              params={ sectionId: id, limit: 2, includeContentTypes: ["Video"], queryFragment }
+            >
+              <for|content| of=nodes>
+                <div class="col">
+                  <marko-web-node
+                    type="company-content"
+                    image-position="top"
+                    card=false
+                    full-height=true
+                  >
+                    <@image
+                      src=get(content, "company.primaryImage.src")
+                      alt=get(content, "company.primaryImage.alt")
+                      is-logo=get(content, "company.primaryImage.isLogo")
+                      fluid=true
+                      ar="16:9"
+                      width=520
+                      link={ href: get(content, "company.siteContext.path") }
+                    />
+                    <@body>
+                      <@header>
+                        <@left>
+                          <marko-web-content-name|{ value }| obj=content.company>Watch ${value}'s Video</marko-web-content-name>
+                        </@left>
+                      </@header>
+                      <@text><marko-web-content-embed-code block-name="node" obj=content /></@text>
+                    </@body>
+                  </marko-web-node>
+                </div>
+              </for>
+            </marko-web-query>
+          </div>
+          <div class="row">
+            <marko-web-query|{ nodes }|
+              name="website-scheduled-content"
+              params={ sectionId: id, limit: 2, includeContentTypes: ["Whitepaper"], queryFragment }
+            >
+              <for|content| of=nodes>
+                <div class="col">
+                  <marko-web-node
+                    type="whitepaper-content"
+                    image-position="top"
+                    card=false
+                    full-height=true
+                  >
+                    <@body>
+                      <@header>
+                        <@left>
+                          <marko-web-content-name|{ value }| obj=content.company>Download ${value}'s Whitepaper</marko-web-content-name>
+                        </@left>
+                      </@header>
+                      <@title><marko-web-content-name obj=content /></@title>
+                      <@text><marko-web-content-body obj=content /></@text>
+                      <@footer>
+                        <@left><marko-core-link href=content.siteContext.path>Download Now!</marko-core-link></@left>
+                      </@footer>
+                    </@body>
+                  </marko-web-node>
+                </div>
+              </for>
+            </marko-web-query>
+          </div>
+
+          <div class="row">
+
+            <div class="col col-lg-12">
+              <hr>
+              <div class="node">
+                <h4>All Global Thought Leaders</h4>
+              </div>
+            </div>
+
+            <marko-web-query|{ nodes }|
+              name="website-scheduled-content"
+              params={ sectionId: id, limit: 27, includeContentTypes: ["Company"], queryFragment }
+            >
+
+              <for|content| of=nodes>
+                <div class="col col-lg-4">
+                  <marko-web-node
+                    type="company-content"
+                    image-position="top"
+                    card=false
+                    full-height=true
+                  >
+                    <@image
+                      src=get(content, "primaryImage.src")
+                      alt=get(content, "primaryImage.alt")
+                      is-logo=get(content, "primaryImage.isLogo")
+                      link={ href: content.siteContext.path }
+                      ar="16:9"
+                      modifiers=["centercap"]
+                      options=imageOpts
+                    />
+                  </marko-web-node>
+                </div>
+              </for>
+            </marko-web-query>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+
+  <@load-more enabled=false />
+</shared-website-section-page-default-layout>


### PR DESCRIPTION
[#DEV-9](https://southcomm.atlassian.net/browse/DEV-9)

Port the website section override from waterworld.com and setup new Global Thought Leads section on watertechonline.com


![GlobalThoughtLeaders](https://user-images.githubusercontent.com/3845869/89813469-5ecd7a80-db07-11ea-81c0-b14593b10381.png)
