### PR TITLE
Homepage block update

### DIFF
--- a/sites/locksmithledger.com/server/templates/index.marko
+++ b/sites/locksmithledger.com/server/templates/index.marko
@@ -33,7 +33,7 @@ $ const adSlots = ({ aliases }) => ({
       </div>
 
       <div class="col-lg-4 mb-block">
-        <shared-website-section-list-block alias="sponsored" link-header=false>
+        <shared-website-section-list-block alias="multimedia" link-header=true>
           <@list modifiers=["sponsored"]>
             <@node modifiers=["sponsored"] />
             <@body>


### PR DESCRIPTION
Swapped out “Sponsored” with “Multimedia”, left the gray background.  https://southcomm.atlassian.net/browse/DEV-126
![Screen Shot 2020-08-21 at 8 44 19 AM](https://user-images.githubusercontent.com/12496550/90897308-8edc0f80-e38a-11ea-8b1b-ad6e5125f990.png)
