### PR TITLE
Switch sort when searching

### DIFF
--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -86,7 +86,11 @@
                     <a :href="`/${item.id}`" v-html="item.name" />
                   </h5>
                   <div v-if="item.teaser === '...'" class="node__text node__text--teaser" />
-                  <div v-else-if="item.teaser" class="node__text node__text--teaser" v-html="item.teaser" />
+                  <div
+                    v-else-if="item.teaser"
+                    class="node__text node__text--teaser"
+                    v-html="item.teaser"
+                  />
                 </div>
                 <div class="node__footer node__footer--body">
                   <div class="node__footer-right">

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -185,7 +185,7 @@ export default {
         .setPage(page)
         .search();
     },
-    sortedClicked(itmes) {
+    sortedClicked(items) {
       const uri = window.location.search.substring(1);
       const params = new URLSearchParams(uri);
       if (params.get(`${this.tenantKey}[query]`)) {
@@ -193,7 +193,7 @@ export default {
       } else {
         this.sorted = false;
       }
-      return itmes;
+      return items;
     },
     getDate(date) {
       return moment(date).format(this.dateFormat);

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -198,9 +198,6 @@ export default {
     getDate(date) {
       return moment(date).format(this.dateFormat);
     },
-    nameHTML() {
-      return this.name;
-    },
   },
 };
 </script>

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -166,12 +166,12 @@ export default {
       this.searchApiKey,
     );
   },
-methods: {
+  methods: {
     searchFunction(helper) {
       const page = helper.getPage();
       // if query null set default sort to published
       if (!this.sorted) {
-        let index = (helper.state.query)? this.tenantKey : `${this.tenantKey}_published`;
+        const index = (helper.state.query) ? this.tenantKey : `${this.tenantKey}_published`;
         helper.setIndex(index).getIndex();
       }
 
@@ -184,8 +184,8 @@ methods: {
         .search();
     },
     sortedClicked(itmes) {
-      let uri = window.location.search.substring(1);
-      let params = new URLSearchParams(uri);
+      const uri = window.location.search.substring(1);
+      const params = new URLSearchParams(uri);
       if (params.get(`${this.tenantKey}[query]`)) {
         this.sorted = true;
       } else {

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/no-v-html-->
 <template>
   <ais-instant-search
     :index-name="tenantKey"
@@ -82,20 +83,16 @@
               <div class="node__body">
                 <div class="node__contents node__contents--body">
                   <h5 class="node__title">
-                    <a :href="`/${item.id}`">
-                      {{ item.name }}
-                    </a>
+                    <a :href="`/${item.id}`" v-html="item.name" />
                   </h5>
                   <div v-if="item.teaser === '...'" class="node__text node__text--teaser" />
-                  <div v-else-if="item.teaser" class="node__text node__text--teaser">
-                    {{ item.teaser }}
+                  <div v-else-if="item.teaser" class="node__text node__text--teaser" v-html="item.teaser" />
+                </div>
+                <div class="node__footer node__footer--body">
+                  <div class="node__footer-right">
+                    <div>{{ getDate(item.published) }}</div>
                   </div>
                 </div>
-                <!-- <div class="node__footer node__footer--body">
-                  <div class="node__footer-right">
-                    <div>{{ item.published }}</div>
-                  </div>
-                </div> -->
               </div>
             </div>
           </div>
@@ -119,6 +116,7 @@ import {
   AisHits,
   AisPagination,
 } from 'vue-instantsearch';
+import moment from 'moment';
 import algoliasearch from 'algoliasearch/lite';
 import { history as historyRouter } from 'instantsearch.js/es/lib/routers';
 import { simple as simpleMapping } from 'instantsearch.js/es/lib/stateMappings';
@@ -148,6 +146,10 @@ export default {
     tenantKey: {
       type: String,
       required: true,
+    },
+    dateFormat: {
+      type: String,
+      default: 'MMM Do, YYYY',
     },
   },
 
@@ -192,6 +194,12 @@ export default {
         this.sorted = false;
       }
       return itmes;
+    },
+    getDate(date) {
+      return moment(date).format(this.dateFormat);
+    },
+    nameHTML() {
+      return this.name;
     },
   },
 };

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -178,7 +178,7 @@ export default {
       // if query null set default sort to published
       if (!this.sorted) {
         const index = (helper.state.query) ? this.tenantKey : `${this.tenantKey}_published`;
-        helper.setIndex(index).getIndex();
+        helper.setIndex(index);
       }
 
       const timestamp = new Date().getTime();

--- a/packages/common/browser/algolia/site-search.vue
+++ b/packages/common/browser/algolia/site-search.vue
@@ -20,6 +20,7 @@
             { value: tenantKey, label: 'Relevance' },
             { value: `${tenantKey}_published`, label: 'Published Date' },
           ]"
+          :transform-items="sortedClicked"
         />
         <div
           slot="showMoreLabel"
@@ -152,18 +153,10 @@ export default {
 
   data() {
     return {
+      sorted: false,
       routing: {
         router: historyRouter(),
         stateMapping: simpleMapping(),
-      },
-      searchFunction(helper) {
-        const page = helper.getPage();
-        helper
-          .addNumericRefinement('published', '<', new Date().getTime())
-          .addNumericRefinement('unpublished', '>', new Date().getTime())
-          .addNumericRefinement('status', '=', 1)
-          .setPage(page)
-          .search();
       },
     };
   },
@@ -172,6 +165,34 @@ export default {
       this.applicationId,
       this.searchApiKey,
     );
+  },
+methods: {
+    searchFunction(helper) {
+      const page = helper.getPage();
+      // if query null set default sort to published
+      if (!this.sorted) {
+        let index = (helper.state.query)? this.tenantKey : `${this.tenantKey}_published`;
+        helper.setIndex(index).getIndex();
+      }
+
+      const timestamp = new Date().getTime();
+      helper
+        .addNumericRefinement('published', '<', timestamp)
+        .addNumericRefinement('unpublished', '>', timestamp)
+        .addNumericRefinement('status', '=', 1)
+        .setPage(page)
+        .search();
+    },
+    sortedClicked(itmes) {
+      let uri = window.location.search.substring(1);
+      let params = new URLSearchParams(uri);
+      if (params.get(`${this.tenantKey}[query]`)) {
+        this.sorted = true;
+      } else {
+        this.sorted = false;
+      }
+      return itmes;
+    },
   },
 };
 </script>

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -26,6 +26,7 @@
     "graphql": "^14.5.4",
     "graphql-tag": "^2.10.1",
     "instantsearch.js": "^4.7.0",
+    "moment": "^2.28.0",
     "node-fetch": "^2.6.0",
     "vue-instantsearch": "^3.1.0",
     "vue-recaptcha": "^1.2.0",

--- a/sites/offshore-mag.com/server/styles/index.scss
+++ b/sites/offshore-mag.com/server/styles/index.scss
@@ -36,6 +36,7 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@endeavor-business-media/package-common/scss/card-deck-flow";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/node";
 // @todo this should be remove once contact us is in core
+@import "../../node_modules/@endeavor-business-media/package-common/scss/algolia";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/contact-us-form";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/directory";
 @import "../../node_modules/@endeavor-business-media/package-inquiry/scss/index";

--- a/sites/offshore-mag.com/server/templates/search.marko
+++ b/sites/offshore-mag.com/server/templates/search.marko
@@ -1,7 +1,8 @@
 import GAM from "../../config/gam";
-import GCSE from "../../config/gcse";
 
-$ const { config } = out.global;
+$ const { config, site } = out.global;
+$ const applicationId = site.get("algolia.applicationId");
+$ const searchApiKey = site.get("algolia.searchApiKey");
 
 $ const type = "search";
 $ const title = "Search";
@@ -29,7 +30,12 @@ $ const description = `Search ${config.siteName()}`;
       <@section>
         <div class="row">
           <div class="col">
-            <marko-web-gcse-simple-search-box api-key=GCSE.getApiKey() />
+            <if(applicationId && searchApiKey)>
+              <common-algolia-site-search application-id=applicationId search-api-key=searchApiKey />
+            </if>
+            <else>
+              $ warn("Unable to load search: no `algolia.applicationId && algoliaApiKey` values are configured.");
+            </else>
           </div>
         </div>
       </@section>

--- a/sites/strategies-u.com/server/styles/index.scss
+++ b/sites/strategies-u.com/server/styles/index.scss
@@ -32,6 +32,7 @@ $theme-site-header-breakpoints: (
 @import "../../node_modules/@endeavor-business-media/package-common/scss/card-deck-flow";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/node";
 // @todo this should be remove once contact us is in core
+@import "../../node_modules/@endeavor-business-media/package-common/scss/algolia";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/contact-us-form";
 @import "../../node_modules/@endeavor-business-media/package-common/scss/directory";
 @import "../../node_modules/@endeavor-business-media/package-inquiry/scss/index";

--- a/sites/strategies-u.com/server/templates/search.marko
+++ b/sites/strategies-u.com/server/templates/search.marko
@@ -1,7 +1,8 @@
 import GAM from "../../config/gam";
-import GCSE from "../../config/gcse";
 
-$ const { config } = out.global;
+$ const { config, site } = out.global;
+$ const applicationId = site.get("algolia.applicationId");
+$ const searchApiKey = site.get("algolia.searchApiKey");
 
 $ const type = "search";
 $ const title = "Search";
@@ -29,7 +30,12 @@ $ const description = `Search ${config.siteName()}`;
       <@section>
         <div class="row">
           <div class="col">
-            <marko-web-gcse-simple-search-box api-key=GCSE.getApiKey() />
+            <if(applicationId && searchApiKey)>
+              <common-algolia-site-search application-id=applicationId search-api-key=searchApiKey />
+            </if>
+            <else>
+              $ warn("Unable to load search: no `algolia.applicationId && algoliaApiKey` values are configured.");
+            </else>
           </div>
         </div>
       </@section>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,6 +7945,11 @@ moment-timezone@^0.5.26:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
+moment@^2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.28.0.tgz#cdfe73ce01327cee6537b0fafac2e0f21a237d75"
+  integrity sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
By default, it will use published date. If you search for something it will switch to relevance.

This should fix pages like this, that look bad. https://www.laserfocusworld.com/search

![offshore](https://user-images.githubusercontent.com/3845869/93156789-78497f80-f6ce-11ea-84a7-d0680cc49f97.png)
