### PR TITLE
Update category names

### DIFF
--- a/sites/ledsmagazine.com/server/categories.js
+++ b/sites/ledsmagazine.com/server/categories.js
@@ -501,7 +501,7 @@ module.exports = [
       },
       {
         id: 34564,
-        name: 'Surface-mount LEDs (',
+        name: 'Surface-mount LEDs (<0.5W)',
         href: '/directory/led-packages/surface-mount-leds-',
       },
       {
@@ -516,7 +516,7 @@ module.exports = [
       },
       {
         id: 34567,
-        name: 'White LEDs (',
+        name: 'White LEDs (<0.5W)',
         href: '/directory/led-packages/white-leds-',
       },
     ],


### PR DESCRIPTION
Currently in Base as: Industry Guide > LED Packages > Surface-mount LEDs (

Should be: Industry Guide > LED Packages > Surface-mount LEDs (<0.5W)

Currently in Base as: Industry Guide > LED Packages > White LEDs (

Should be: Industry Guide > LED Packages > White LEDs (<0.5W)