### PR TITLE
update nav and add News & Notes to homepage

### DIFF
--- a/sites/processingmagazine.com/config/navigation.js
+++ b/sites/processingmagazine.com/config/navigation.js
@@ -15,8 +15,10 @@ module.exports = {
     items: [
       { href: '/subscribe', label: 'Subscribe' },
       { href: '/magazine', label: 'Magazine' },
-      { href: '/webinars', label: 'Webinars' },
       { href: '/events', label: 'Events' },
+      { href: '/news-notes', label: 'News & Notes' },
+      { href: '/videos', label: 'Videos' },
+      { href: '/webinars', label: 'Webinars' },
       { href: '/breakthrough-products', label: 'Breakthrough Products Awards' },
     ],
   },
@@ -51,8 +53,10 @@ module.exports = {
       label: 'Resources',
       items: [
         { href: '/magazine', label: 'Magazine' },
-        { href: '/webinars', label: 'Webinars' },
         { href: '/events', label: 'Events' },
+        { href: '/news-notes', label: 'News & Notes' },
+        { href: '/videos', label: 'Videos' },
+        { href: '/webinars', label: 'Webinars' },
         { href: '/breakthrough-products', label: 'Breakthrough Products Awards' },
       ],
     },

--- a/sites/processingmagazine.com/server/templates/index.marko
+++ b/sites/processingmagazine.com/server/templates/index.marko
@@ -24,7 +24,7 @@ $ const adSlots = ({ aliases }) => ({
       <div class="col-lg-8">
         <div class="row">
           <div class="col-lg-6 mb-block">
-            <shared-website-section-list-block alias="covid-19">
+            <shared-website-section-list-block alias="news-notes">
               <@query-params limit=3 />
               <@native-x index=2 />
             </shared-website-section-list-block>


### PR DESCRIPTION
[**DEV-228**}(https://southcomm.atlassian.net/browse/DEV-228)
 - add `News & Notes` & `Videos` to navigation
 - update homepage Covid section with News & Notes

![Screen Shot 2020-09-23 at 1 50 58 PM](https://user-images.githubusercontent.com/3845869/94056682-3f7f6980-fda4-11ea-9632-bdfa9ed78336.png)
