### PR TITLE
Remove drop-shadow from logo

### DIFF
--- a/sites/hpnonline.com/server/styles/index.scss
+++ b/sites/hpnonline.com/server/styles/index.scss
@@ -8,6 +8,7 @@ $leaders-primary-color: #000;
 $leaders-primary-color-light: lighten($leaders-primary-color, 10%);
 $leaders-accent-color: $primary;
 
+$theme-site-navbar-logo-drop-shadow: "";
 $theme-site-navbar-primary-bg-color: $primary;
 $theme-site-navbar-secondary-bg-color: #fff;
 $theme-site-navbar-secondary-type: light;


### PR DESCRIPTION
Per Tracy via https://southcomm.atlassian.net/browse/DEV-246

Without drop-shadow:
<img width="259" alt="Screen Shot 2020-09-30 at 10 59 06 AM" src="https://user-images.githubusercontent.com/12496550/94710137-1a42ac00-030c-11eb-9cb3-81c3cb9d23b6.png">

With drop-shadow (currently on prod):
<img width="270" alt="Screen Shot 2020-09-30 at 10 57 45 AM" src="https://user-images.githubusercontent.com/12496550/94710157-20d12380-030c-11eb-9378-8b07848d8354.png">
