### PR TITLE
Update TPA’s /subscribe page

### DIFF
--- a/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
+++ b/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
@@ -1,5 +1,4 @@
 $ const { config } = out.global;
-$ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
   description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`

--- a/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
+++ b/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
@@ -1,7 +1,8 @@
+$ const { config } = out.global;
 $ const dragonForms = require('../../../config/dragon-forms');
 
 <shared-subscribe-page-layout
-  description="AviationPros has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of AviationPros at your fingertips."
+  description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
 >
   <@newsletter-section>
     <div class="row">
@@ -11,17 +12,9 @@ $ const dragonForms = require('../../../config/dragon-forms');
         <p>
           <marko-web-link
             class="font-weight-bold"
-            href=dragonForms.getFormUrl('newsletterSubscribe')
+            href="http://cygnuscorporate.wufoo.com/forms/m1mu6gxu02je8ro/"
             target="_blank">
-            Subscribe
-          </marko-web-link>
-        </p>
-        <p>
-          <marko-web-link
-            class="font-weight-bold"
-            href=dragonForms.getFormUrl('newsletterManage')
-            target="_blank">
-            Manage Preferences
+            Subscribe / Manage Preferences
           </marko-web-link>
         </p>
         <hr>


### PR DESCRIPTION
Swapped out “AviationPros” with `config.siteName` in the page description, combined the Subscribe/Manage Preferences link into one and manually set the wufoo form link (instead of calling a dragonform url in dragon-form.js)

![image](https://user-images.githubusercontent.com/12496550/95381183-6746f500-08ad-11eb-9148-2394f83507c2.png)
