### PR TITLE
Update SIW navigation

### DIFF
--- a/sites/securityinfowatch.com/config/navigation.js
+++ b/sites/securityinfowatch.com/config/navigation.js
@@ -10,7 +10,7 @@ module.exports = {
       { href: '/residential-technologies', label: 'Residential Tech' },
       { href: '/alarms-monitoring', label: 'Alarms & Monitoring' },
       { href: '/cybersecurity', label: 'Cybersecurity' },
-      { href: '/covid-19', label: 'COVID-19' },
+      { href: '/perimeter-security', label: 'Perimeter Security' },
     ],
   },
   secondary: {

--- a/sites/securityinfowatch.com/server/styles/index.scss
+++ b/sites/securityinfowatch.com/server/styles/index.scss
@@ -11,15 +11,25 @@ $leaders-accent-color: $primary;
 $theme-site-navbar-primary-bg-color: $primary;
 $theme-site-navbar-secondary-bg-color: #000;
 
+$theme-site-navbar-primary-font-size:       14px;
+$theme-site-navbar-primary-font-size-sm:    $theme-site-navbar-primary-font-size - 2;
+
 $theme-newsletter-block-bg-color: #000;
 $theme-newsletter-block-button-bg-color: $primary;
 
+// Overriding these corrects a mobile issue with the tertiary nav
+$theme-site-navbar-secondary-font-size: 12px;
+// Set it back to previous default font size on larger screens
+@media (min-width: 450px) {
+  $theme-site-navbar-secondary-font-size: 14px;
+}
+
 $theme-site-header-breakpoints: (
-  hide-primary: 1050px,
-  hide-secondary: 906px,
-  small-logo: 1015px,
-  small-text-primary: 10000px,
-  small-text-secondary: 10000px
+  hide-primary: 990px,
+  hide-secondary: 800px,
+  small-logo: 1125px,
+  small-text-primary: 1125px,
+  small-text-secondary: 1125px
 );
 
 @import "../../node_modules/@endeavor-business-media/package-shared/scss/cygnus-skin";


### PR DESCRIPTION
https://southcomm.atlassian.net/browse/DEV-304

- On the primary navigation, replace ‘Covid-19’ with ‘Perimeter Security’
- Update style settings for navigation to accommodate a lengthier menu

New:
<img width="1232" alt="Screen Shot 2020-10-22 at 1 46 14 PM" src="https://user-images.githubusercontent.com/6343242/96914499-14576b00-1473-11eb-8e0b-329ccdd559f6.png">

Current:
<img width="1247" alt="Screen Shot 2020-10-22 at 1 44 48 PM" src="https://user-images.githubusercontent.com/6343242/96914500-14f00180-1473-11eb-8d55-b8ff51616886.png">
