### PR TITLE
Correct footer layout on mobile

### DIFF
--- a/packages/shared/scss/core.scss
+++ b/packages/shared/scss/core.scss
@@ -172,3 +172,12 @@ $pswp__root-z-index: $theme-site-header-z-index + 1 !default;
     margin-top: map-get($spacers, block);
   }
 }
+
+.site-footer {
+  &__items {
+    flex-direction: column;
+    @include media-breakpoint-up(lg) {
+      flex-direction: row;
+    }
+  }
+}


### PR DESCRIPTION
Current:
<img width="394" alt="Screen Shot 2020-10-22 at 2 32 44 PM" src="https://user-images.githubusercontent.com/6343242/96915299-15d56300-1474-11eb-8759-f094854e50ff.png">


New:
<img width="380" alt="Screen Shot 2020-10-22 at 2 36 07 PM" src="https://user-images.githubusercontent.com/6343242/96915291-1241dc00-1474-11eb-9daa-ecf16171e0d4.png">
