### PR TITLE
Update TPA Subscribe page verbiage

### DIFF
--- a/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
+++ b/sites/taxpracticeadvisor.com/server/templates/subscribe/index.marko
@@ -1,13 +1,13 @@
 $ const { config } = out.global;
 
 <shared-subscribe-page-layout
-  description=`${config.siteName()} has products that deliver powerful content to you in a variety of forms including print, online, email and social media. To subscribe to a product or manage your current subscription, click below and put the power of ${config.siteName()} at your fingertips.`
+  description=`${config.siteName()} delivers power content to tax providers with this website and also our weekly newsletter. To subscribe or manage your current subscription, please click below and put the power of ${config.siteName()} at your fingertips.`
 >
   <@newsletter-section>
     <div class="row">
       <div class="col">
-        <h4>Newsletters</h4>
-        <p>Stay up-to-date on industry news and events, new product launches and more. Select from our list of targeted email offerings to stay informed on the topics that matter to you and your business.</p>
+        <h4>Newsletter</h4>
+        <p>Stay up-to-date on news relating to tax preparers, new product launches, and more.</p>
         <p>
           <marko-web-link
             class="font-weight-bold"
@@ -21,12 +21,13 @@ $ const { config } = out.global;
     </div>
   </@newsletter-section>
 
-  <@magazine-section>
+  <!-- <@magazine-section>
     <div class="row">
       <div class="col mb-block">
         <h4>Magazines</h4>
       </div>
     </div>
     <shared-magazine-publications-block />
-  </@magazine-section>
+  </@magazine-section> -->
+
 </shared-subscribe-page-layout>


### PR DESCRIPTION
Per Carrie via https://southcomm.atlassian.net/browse/DEV-294

Updated verbiage and removed Magazine block:
<img width="1041" alt="Screen Shot 2020-10-27 at 10 46 12 AM" src="https://user-images.githubusercontent.com/12496550/97332053-05dccb00-1848-11eb-81c8-f35aaf7cc627.png">
