### PR TITLE
GAM alias for FH’s /video page

### DIFF
--- a/sites/firehouse.com/config/gam.js
+++ b/sites/firehouse.com/config/gam.js
@@ -138,6 +138,14 @@ config
     { name: 'rail2', templateName: 'RAIL2', path: 'evt/rail2' },
     { name: 'load-more', templateName: 'LM', path: 'evt/load-more' },
     { name: 'reskin', path: 'evt/reskin' },
+  ])
+  .setAliasAdUnits('video', [
+    { name: 'lb1', templateName: 'LB1', path: 'video/lb1' },
+    { name: 'lb2', templateName: 'LB2', path: 'video/lb2' },
+    { name: 'rail1', templateName: 'RAIL1', path: 'video/rail1' },
+    { name: 'rail2', templateName: 'RAIL2', path: 'video/rail2' },
+    { name: 'load-more', templateName: 'LM', path: 'video/load-more' },
+    { name: 'reskin', path: 'video/reskin' },
   ]);
 
 module.exports = config;


### PR DESCRIPTION
Right now they have /video redirecting to /videos, so when this goes live we'll reverse that redirect and their videos page will be converted to a schedule-based page like any other standard section.  Full convo can be found here: https://southcomm.atlassian.net/browse/DEV-326