### PR TITLE
Remove /videos and replace with /video

### DIFF
--- a/sites/firehouse.com/config/navigation.js
+++ b/sites/firehouse.com/config/navigation.js
@@ -78,7 +78,7 @@ module.exports = {
         { href: '/events', label: 'Events' },
         { href: '/historical-incidents', label: 'Historical Incidents' },
         { href: '/special-content', label: 'Special Content' },
-        { href: '/videos', label: 'Videos' },
+        { href: '/video', label: 'Videos' },
         { href: 'https://cygnuscorporate.wufoo.com/forms/msifezv1jvw2kd/', label: 'Product Submission Form', target: '_blank' },
         { href: 'https://cygnuscorporate.wufoo.com/forms/m1kqij91xw16l1/', label: 'Company Submission Form', target: '_blank' },
       ],

--- a/sites/firehouse.com/server/routes/published-content.js
+++ b/sites/firehouse.com/server/routes/published-content.js
@@ -1,9 +1,7 @@
 const webinars = require('@endeavor-business-media/package-shared/templates/published-content/webinars');
 const events = require('@endeavor-business-media/package-shared/templates/published-content/events');
-const videos = require('@endeavor-business-media/package-shared/templates/published-content/videos');
 
 module.exports = (app) => {
   app.get('/events', (_, res) => { res.marko(events); });
   app.get('/webinars', (_, res) => { res.marko(webinars); });
-  app.get('/videos', (_, res) => { res.marko(videos); });
 };

--- a/sites/firehouse.com/server/templates/index.marko
+++ b/sites/firehouse.com/server/templates/index.marko
@@ -76,7 +76,7 @@ $ const adSlots = ({ aliases }) => ({
       <div class="col">
         <shared-published-content-cards-block content-types=["Video"]>
           <@header>
-            <marko-web-link href="/videos">Videos</marko-web-link>
+            <marko-web-link href="/video">Videos</marko-web-link>
           </@header>
           <@query-params limit=4 />
         </shared-published-content-cards-block>


### PR DESCRIPTION
FH is moving to a schedule-based video page, so the homepage block, navigation, and routes are being updated with the new alias.